### PR TITLE
FEATURE: include metadata with streaming call ends (on error or success)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "grpc-methods",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "Method wrappers for Grpc to include logging and promises",
   "main": "src/index.js",
   "scripts": {

--- a/src/grpc-method.js
+++ b/src/grpc-method.js
@@ -72,6 +72,7 @@ class GrpcMethod {
    * @typedef {Object} GrpcError
    * @property {number} code Grpc Status code for the error
    * @property {string} message Message to be delivered to the client
+   * @property {grpc#Metadata} metadata Metadata to be delivered to the client
    */
 
   /**

--- a/src/grpc-method.js
+++ b/src/grpc-method.js
@@ -89,7 +89,8 @@ class GrpcMethod {
 
     return {
       code: grpc.status.INTERNAL,
-      message: `${this.messageId} ${message}`
+      message: `${this.messageId} ${message}`,
+      metadata: this.metadata
     }
   }
 

--- a/src/grpc-method.js
+++ b/src/grpc-method.js
@@ -91,7 +91,7 @@ class GrpcMethod {
     return {
       code: grpc.status.INTERNAL,
       message: `${this.messageId} ${message}`,
-      metadata: this.metadata
+      metadata: this.metadata()
     }
   }
 

--- a/src/grpc-method.spec.js
+++ b/src/grpc-method.spec.js
@@ -125,7 +125,8 @@ describe('GrpcMethod', () => {
       expect(Object.keys(grpcErr)).to.have.lengthOf(3)
       expect(grpcErr).to.have.property('code')
       expect(grpcErr).to.have.property('message')
-      expect(grpcErr).to.have.property('metadata', grpcMethod.metadata)
+      expect(grpcErr).to.have.property('metadata')
+      expect(grpcErr.metadata).to.be.instanceOf(grpcMetadata)
     })
 
     xit('marks errors as internal')

--- a/src/grpc-method.spec.js
+++ b/src/grpc-method.spec.js
@@ -122,9 +122,10 @@ describe('GrpcMethod', () => {
       const grpcErr = grpcMethod.grpcError(err)
 
       expect(grpcErr).to.be.a('object')
-      expect(Object.keys(grpcErr)).to.have.lengthOf(2)
+      expect(Object.keys(grpcErr)).to.have.lengthOf(3)
       expect(grpcErr).to.have.property('code')
       expect(grpcErr).to.have.property('message')
+      expect(grpcErr).to.have.property('metadata', grpcMethod.metadata)
     })
 
     xit('marks errors as internal')

--- a/src/grpc-server-streaming-method.js
+++ b/src/grpc-server-streaming-method.js
@@ -39,7 +39,6 @@ class GrpcServerStreamingMethod extends GrpcMethod {
     } catch (e) {
       this.logError(e)
 
-      // TODO: do we need to set metadata somewhere?
       call.destroy(this.grpcError(e))
     }
   }

--- a/src/grpc-server-streaming-method.js
+++ b/src/grpc-server-streaming-method.js
@@ -34,8 +34,8 @@ class GrpcServerStreamingMethod extends GrpcMethod {
       await method(request, this.responses)
 
       this.logRequestEnd()
-      // TODO: is this the write way to terminate a call?
-      call.end()
+
+      call.end(this.metadata)
     } catch (e) {
       this.logError(e)
 

--- a/src/grpc-server-streaming-method.js
+++ b/src/grpc-server-streaming-method.js
@@ -35,7 +35,7 @@ class GrpcServerStreamingMethod extends GrpcMethod {
 
       this.logRequestEnd()
 
-      call.end(this.metadata)
+      call.end(this.metadata())
     } catch (e) {
       this.logError(e)
 

--- a/src/grpc-server-streaming-method.spec.js
+++ b/src/grpc-server-streaming-method.spec.js
@@ -140,6 +140,11 @@ describe('GrpcServerStreamingMethod', () => {
         expect(call.end).to.have.been.calledOnce()
         expect(call.end).to.have.been.calledOn(call)
       })
+
+      it('includes metadata with the stream end', async () => {
+        await grpcMethod.exec(call)
+        expect(call.end).to.have.been.calledWith(grpcMethod.metadata)
+      })
     })
 
     describe('error', () => {

--- a/src/grpc-server-streaming-method.spec.js
+++ b/src/grpc-server-streaming-method.spec.js
@@ -20,6 +20,7 @@ describe('GrpcServerStreamingMethod', () => {
   let logger
   let responses
   let messageId
+  let metadata
 
   beforeEach(() => {
     GrpcMethod = sinon.stub()
@@ -32,6 +33,7 @@ describe('GrpcServerStreamingMethod', () => {
     logResponse = sinon.stub(GrpcServerStreamingMethod.prototype, 'logResponse')
     logError = sinon.stub(GrpcServerStreamingMethod.prototype, 'logError')
     grpcError = sinon.stub(GrpcServerStreamingMethod.prototype, 'grpcError')
+    metadata = sinon.stub(GrpcServerStreamingMethod.prototype, 'metadata')
 
     logger = {
       error: sinon.stub(),
@@ -142,8 +144,14 @@ describe('GrpcServerStreamingMethod', () => {
       })
 
       it('includes metadata with the stream end', async () => {
+        const fakeMetadata = { my: 'fake' }
+        metadata.returns(fakeMetadata)
+
         await grpcMethod.exec(call)
-        expect(call.end).to.have.been.calledWith(grpcMethod.metadata)
+        
+        expect(metadata).to.have.been.calledOnce()
+        expect(metadata).to.have.been.calledOn(grpcMethod)
+        expect(call.end).to.have.been.calledWith(fakeMetadata)
       })
     })
 


### PR DESCRIPTION
### Description
Currently server-streaming RPC methods don't include metadata.
This PR adds metadata on error or on success.

On error, the `metadata` is added to the error object which is in turn passed to `destroy`.

On success, the `metadata` is passed to the `end` method (see: https://github.com/grpc/grpc-node/blob/399ae5ed8edf0e6e95c08d5f6fd538e297c24f8a/packages/grpc-native-core/src/server.js#L186)

### Related PRs
None

### Todo
- [x] Tests
- [x] Docs
- [ ] Trello