### PR TITLE
Handle client cancellations on streaming requests

### DIFF
--- a/src/grpc-server-streaming-method.js
+++ b/src/grpc-server-streaming-method.js
@@ -9,6 +9,7 @@ class GrpcServerStreamingMethod extends GrpcMethod {
    * @typedef {Object} GrpcServerStreamingMethod~request
    * @extends {GrpcMethod~request}
    * @property {Function} send Send data back to the client
+   * @property {Function} onCancel Trigger a listener when the client cancels the stream
    */
 
   /**
@@ -29,6 +30,7 @@ class GrpcServerStreamingMethod extends GrpcMethod {
         params: call.request,
         logger: logger,
         send: this.send.bind(this, call),
+        onCancel: (fn) => { call.on('cancelled', fn) },
         metadata: {},
         ...requestOptions
       }

--- a/src/grpc-server-streaming-method.js
+++ b/src/grpc-server-streaming-method.js
@@ -31,6 +31,7 @@ class GrpcServerStreamingMethod extends GrpcMethod {
         logger: logger,
         send: this.send.bind(this, call),
         onCancel: (fn) => { call.on('cancelled', fn) },
+        onError: (fn) => { call.on('error', fn) },
         metadata: {},
         ...requestOptions
       }
@@ -39,6 +40,11 @@ class GrpcServerStreamingMethod extends GrpcMethod {
 
       call.on('cancelled', () => {
         this.logRequestCancel()
+        this.logRequestEnd()
+      })
+
+      call.on('error', (e) => {
+        this.logError(e)
         this.logRequestEnd()
       })
 

--- a/src/grpc-server-streaming-method.spec.js
+++ b/src/grpc-server-streaming-method.spec.js
@@ -139,6 +139,24 @@ describe('GrpcServerStreamingMethod', () => {
         expect(call.on).to.have.been.calledWith('cancelled', fakeListener)
       })
 
+      it('includes an onError function', () => {
+        grpcMethod.exec(call)
+        expect(method).to.have.been.calledWith(sinon.match({ send: sinon.match.func }))
+      })
+
+      it('sets onError to the cancelled handler', () => {
+        const fakeListener = function () {
+          return 'myfake'
+        }
+
+        grpcMethod.exec(call)
+        const request = method.args[0][0]
+
+        request.onError(fakeListener)
+
+        expect(call.on).to.have.been.calledWith('error', fakeListener)
+      })
+
       it('includes a metadata object', () => {
         grpcMethod.exec(call)
         expect(method).to.have.been.calledWith(sinon.match({ metadata: {} }))

--- a/src/grpc-server-streaming-method.spec.js
+++ b/src/grpc-server-streaming-method.spec.js
@@ -121,6 +121,24 @@ describe('GrpcServerStreamingMethod', () => {
         expect(grpcMethod.send).to.have.been.calledOn(grpcMethod)
       })
 
+      it('includes an onCancel function', () => {
+        grpcMethod.exec(call)
+        expect(method).to.have.been.calledWith(sinon.match({ send: sinon.match.func }))
+      })
+
+      it('sets onCancel to the cancelled handler', () => {
+        const fakeListener = function () {
+          return 'myfake'
+        }
+
+        grpcMethod.exec(call)
+        const request = method.args[0][0]
+
+        request.onCancel(fakeListener)
+
+        expect(call.on).to.have.been.calledWith('cancelled', fakeListener)
+      })
+
       it('includes a metadata object', () => {
         grpcMethod.exec(call)
         expect(method).to.have.been.calledWith(sinon.match({ metadata: {} }))


### PR DESCRIPTION
When clients cancel streaming requests, implementers should be able to handle those cancellations in application specific ways.

This PR exposes a new function `onCancel` on the `ServerStreaming~request` object, allowing implementers to implement special handling.

### todos
- [x] tests
- [x] docs