### PR TITLE
FIX - Update method signature for auth

### DIFF
--- a/CHANGE_LOG
+++ b/CHANGE_LOG
@@ -1,3 +1,7 @@
+v0.6.3 - dannypaz
+
+- Update method signature of grpc-method to take in an AUTH parameter into the requestOptions hash. This changes how authentication is provided to each grpc-method handler
+
 v0.6.2 - dannypaz
 
 - Added authentication to grpc unary/streaming calls to allow the user to check metadata credentials BEFORE a route is submitted. This

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "grpc-methods",
-  "version": "0.6.2",
+  "version": "0.6.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "grpc-methods",
-  "version": "0.6.2",
+  "version": "0.6.3",
   "description": "Method wrappers for Grpc to include logging and promises",
   "main": "src/index.js",
   "scripts": {

--- a/src/grpc-method.js
+++ b/src/grpc-method.js
@@ -32,7 +32,7 @@ class GrpcMethod {
    * @param  {GrpcMethod~method} auth method called before request
    * @return {GrpcMethod}
    */
-  constructor (method, messageId = '', { logger = console, ...requestOptions } = {}, responses = {}, auth = null) {
+  constructor (method, messageId = '', { logger = console, auth = null, ...requestOptions } = {}, responses = {}) {
     // Method definition
     this.method = method
 

--- a/src/grpc-method.spec.js
+++ b/src/grpc-method.spec.js
@@ -81,7 +81,7 @@ describe('GrpcMethod', () => {
     })
 
     it('assigns an authorization function if present', () => {
-      const grpcMethod = new GrpcMethod(method, messageId, { logger, ...requestOptions }, responses, auth)
+      const grpcMethod = new GrpcMethod(method, messageId, { logger, auth, ...requestOptions }, responses)
 
       expect(grpcMethod).to.have.property('auth')
       expect(grpcMethod.auth).to.be.equal(auth)

--- a/src/grpc-server-streaming-method.spec.js
+++ b/src/grpc-server-streaming-method.spec.js
@@ -79,7 +79,7 @@ describe('GrpcServerStreamingMethod', () => {
     let grpcMethod
 
     beforeEach(() => {
-      grpcMethod = new GrpcServerStreamingMethod(method, messageId, { logger, ...requestOptions }, responses, auth)
+      grpcMethod = new GrpcServerStreamingMethod(method, messageId, { logger, auth, ...requestOptions }, responses)
     })
 
     it('logs the start of the request', async () => {

--- a/src/grpc-unary-method.spec.js
+++ b/src/grpc-unary-method.spec.js
@@ -74,7 +74,7 @@ describe('GrpcUnaryMethod', () => {
     let grpcMethod
 
     beforeEach(() => {
-      grpcMethod = new GrpcUnaryMethod(method, messageId, { logger, ...requestOptions }, responses, auth)
+      grpcMethod = new GrpcUnaryMethod(method, messageId, { logger, auth, ...requestOptions }, responses)
     })
 
     it('logs the start of the request', () => {


### PR DESCRIPTION
This PR removes the need for an additional `auth` parameter at the end of grpc-methods and instead uses the requestOptions object to define the auth function for each call. 