### PR TITLE
exclude spec and test files from coverage check

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,8 +24,7 @@
   },
   "nyc": {
     "exclude": [
-      "**/*.spec.js",
-      "test/"
+      "**/*.spec.js"
     ]
   },
   "author": "",

--- a/package.json
+++ b/package.json
@@ -22,6 +22,12 @@
       "chai"
     ]
   },
+  "nyc": {
+    "exclude": [
+      "**/*.spec.js",
+      "test/"
+    ]
+  },
   "author": "",
   "license": "MIT",
   "bugs": {


### PR DESCRIPTION
Removes spec and test files from nyc coverage check