### PR TITLE
fix sec vuln with lodash and just-extend

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4,13 +4,165 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
-    "@sinonjs/formatio": {
-      "version": "2.0.0",
-      "resolved": "http://registry.npmjs.org/@sinonjs/formatio/-/formatio-2.0.0.tgz",
-      "integrity": "sha512-ls6CAMA6/5gG+O/IdsBcblvnd8qcO/l1TYoNeAzp3wcISOxlPXQEus0mLcdwazEkWjaBdaJ3TaxmNgCLWwvWzg==",
+    "@babel/code-frame": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0.tgz",
+      "integrity": "sha512-OfC2uemaknXr87bdLUkWog7nYuliM9Ij5HUcajsVcMCpQrcLmtxRbVFTIqmcSkSeYRBFBRxs2FiUqFJDLdiebA==",
       "dev": true,
       "requires": {
-        "samsam": "1.3.0"
+        "@babel/highlight": "^7.0.0"
+      }
+    },
+    "@babel/generator": {
+      "version": "7.3.2",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.3.2.tgz",
+      "integrity": "sha512-f3QCuPppXxtZOEm5GWPra/uYUjmNQlu9pbAD8D/9jze4pTY83rTtB1igTBSwvkeNlC5gR24zFFkz+2WHLFQhqQ==",
+      "dev": true,
+      "requires": {
+        "@babel/types": "^7.3.2",
+        "jsesc": "^2.5.1",
+        "lodash": "^4.17.10",
+        "source-map": "^0.5.0",
+        "trim-right": "^1.0.1"
+      }
+    },
+    "@babel/helper-function-name": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.1.0.tgz",
+      "integrity": "sha512-A95XEoCpb3TO+KZzJ4S/5uW5fNe26DjBGqf1o9ucyLyCmi1dXq/B3c8iaWTfBk3VvetUxl16e8tIrd5teOCfGw==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-get-function-arity": "^7.0.0",
+        "@babel/template": "^7.1.0",
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "@babel/helper-get-function-arity": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.0.0.tgz",
+      "integrity": "sha512-r2DbJeg4svYvt3HOS74U4eWKsUAMRH01Z1ds1zx8KNTPtpTL5JAsdFv8BNyOpVqdFhHkkRDIg5B4AsxmkjAlmQ==",
+      "dev": true,
+      "requires": {
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "@babel/helper-split-export-declaration": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.0.0.tgz",
+      "integrity": "sha512-MXkOJqva62dfC0w85mEf/LucPPS/1+04nmmRMPEBUB++hiiThQ2zPtX/mEWQ3mtzCEjIJvPY8nuwxXtQeQwUag==",
+      "dev": true,
+      "requires": {
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "@babel/highlight": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.0.0.tgz",
+      "integrity": "sha512-UFMC4ZeFC48Tpvj7C8UgLvtkaUuovQX+5xNWrsIoMG8o2z+XFKjKaN9iVmS84dPwVN00W4wPmqvYoZF3EGAsfw==",
+      "dev": true,
+      "requires": {
+        "chalk": "^2.0.0",
+        "esutils": "^2.0.2",
+        "js-tokens": "^4.0.0"
+      },
+      "dependencies": {
+        "js-tokens": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+          "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+          "dev": true
+        }
+      }
+    },
+    "@babel/parser": {
+      "version": "7.3.2",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.3.2.tgz",
+      "integrity": "sha512-QzNUC2RO1gadg+fs21fi0Uu0OuGNzRKEmgCxoLNzbCdoprLwjfmZwzUrpUNfJPaVRwBpDY47A17yYEGWyRelnQ==",
+      "dev": true
+    },
+    "@babel/template": {
+      "version": "7.2.2",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.2.2.tgz",
+      "integrity": "sha512-zRL0IMM02AUDwghf5LMSSDEz7sBCO2YnNmpg3uWTZj/v1rcG2BmQUvaGU8GhU8BvfMh1k2KIAYZ7Ji9KXPUg7g==",
+      "dev": true,
+      "requires": {
+        "@babel/code-frame": "^7.0.0",
+        "@babel/parser": "^7.2.2",
+        "@babel/types": "^7.2.2"
+      }
+    },
+    "@babel/traverse": {
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.2.3.tgz",
+      "integrity": "sha512-Z31oUD/fJvEWVR0lNZtfgvVt512ForCTNKYcJBGbPb1QZfve4WGH8Wsy7+Mev33/45fhP/hwQtvgusNdcCMgSw==",
+      "dev": true,
+      "requires": {
+        "@babel/code-frame": "^7.0.0",
+        "@babel/generator": "^7.2.2",
+        "@babel/helper-function-name": "^7.1.0",
+        "@babel/helper-split-export-declaration": "^7.0.0",
+        "@babel/parser": "^7.2.3",
+        "@babel/types": "^7.2.2",
+        "debug": "^4.1.0",
+        "globals": "^11.1.0",
+        "lodash": "^4.17.10"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+          "dev": true,
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "ms": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+          "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
+          "dev": true
+        }
+      }
+    },
+    "@babel/types": {
+      "version": "7.3.2",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.3.2.tgz",
+      "integrity": "sha512-3Y6H8xlUlpbGR+XvawiH0UXehqydTmNmEpozWcXymqwcrwYAl5KMvKtQ+TF6f6E08V6Jur7v/ykdDSF+WDEIXQ==",
+      "dev": true,
+      "requires": {
+        "esutils": "^2.0.2",
+        "lodash": "^4.17.10",
+        "to-fast-properties": "^2.0.0"
+      }
+    },
+    "@sinonjs/commons": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.3.0.tgz",
+      "integrity": "sha512-j4ZwhaHmwsCb4DlDOIWnI5YyKDNMoNThsmwEpfHx6a1EpsGZ9qYLxP++LMlmBRjtGptGHFsGItJ768snllFWpA==",
+      "dev": true,
+      "requires": {
+        "type-detect": "4.0.8"
+      }
+    },
+    "@sinonjs/formatio": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@sinonjs/formatio/-/formatio-3.1.0.tgz",
+      "integrity": "sha512-ZAR2bPHOl4Xg6eklUGpsdiIJ4+J1SNag1DHHrG/73Uz/nVwXqjgUtRPLoS+aVyieN9cSbc0E4LsU984tWcDyNg==",
+      "dev": true,
+      "requires": {
+        "@sinonjs/samsam": "^2 || ^3"
+      }
+    },
+    "@sinonjs/samsam": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-3.1.0.tgz",
+      "integrity": "sha512-IXio+GWY+Q8XUjHUOgK7wx8fpvr7IFffgyXb1bnJFfX3001KmHt35Zq4tp7MXZyjJPCLPuadesDYNk41LYtVjw==",
+      "dev": true,
+      "requires": {
+        "@sinonjs/commons": "^1.0.2",
+        "array-from": "^2.1.1",
+        "lodash.get": "^4.4.2"
       }
     },
     "acorn": {
@@ -79,6 +231,12 @@
       "requires": {
         "sprintf-js": "~1.0.2"
       }
+    },
+    "array-from": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/array-from/-/array-from-2.1.1.tgz",
+      "integrity": "sha1-z+nYwmYoudxa7MYqn12PHzUsEZU=",
+      "dev": true
     },
     "array-includes": {
       "version": "3.0.3",
@@ -1608,6 +1766,27 @@
       "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
       "dev": true
     },
+    "istanbul-lib-coverage": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.3.tgz",
+      "integrity": "sha512-dKWuzRGCs4G+67VfW9pBFFz2Jpi4vSp/k7zBcJ888ofV5Mi1g5CUML5GvMvV6u9Cjybftu+E8Cgp+k0dI1E5lw==",
+      "dev": true
+    },
+    "istanbul-lib-instrument": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-3.1.0.tgz",
+      "integrity": "sha512-ooVllVGT38HIk8MxDj/OIHXSYvH+1tq/Vb38s8ixt9GoJadXska4WkGY+0wkmtYCZNYtaARniH/DixUGGLZ0uA==",
+      "dev": true,
+      "requires": {
+        "@babel/generator": "^7.0.0",
+        "@babel/parser": "^7.0.0",
+        "@babel/template": "^7.0.0",
+        "@babel/traverse": "^7.0.0",
+        "@babel/types": "^7.0.0",
+        "istanbul-lib-coverage": "^2.0.3",
+        "semver": "^5.5.0"
+      }
+    },
     "js-tokens": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
@@ -1653,6 +1832,12 @@
         "underscore": "~1.8.3"
       }
     },
+    "jsesc": {
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
+      "integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==",
+      "dev": true
+    },
     "json-parse-better-errors": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
@@ -1681,9 +1866,9 @@
       }
     },
     "just-extend": {
-      "version": "1.1.27",
-      "resolved": "https://registry.npmjs.org/just-extend/-/just-extend-1.1.27.tgz",
-      "integrity": "sha512-mJVp13Ix6gFo3SBAy9U/kL+oeZqzlYYYLQBwXVBlVzIsZwBqGREnOro24oC/8s8aox+rJhtZ2DiQof++IrkA+g==",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/just-extend/-/just-extend-4.0.2.tgz",
+      "integrity": "sha512-FrLwOgm+iXrPV+5zDU6Jqu4gCRXbWEQg2O3SKONsWE4w7AXFRkryS53bpWdaL9cNol+AmR3AEYz6kn+o0fCPnw==",
       "dev": true
     },
     "klaw": {
@@ -1755,9 +1940,9 @@
       "dev": true
     },
     "lolex": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/lolex/-/lolex-2.5.0.tgz",
-      "integrity": "sha512-ghOPAtzYCUWGh9sEawpMtLPMjArrM9sq8qaLEL79aXsIm7I2fpTQANvZkj5gbDgpsjZmDcCdLnlh3YOimLDkXA==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/lolex/-/lolex-3.1.0.tgz",
+      "integrity": "sha512-zFo5MgCJ0rZ7gQg69S4pqBsLURbFw11X68C18OcJjJQbqaXm2NoTrGl1IMM3TIz0/BnN1tIs2tzmmqvCsOMMjw==",
       "dev": true
     },
     "long": {
@@ -1867,16 +2052,24 @@
       "dev": true
     },
     "nise": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/nise/-/nise-1.3.3.tgz",
-      "integrity": "sha512-v1J/FLUB9PfGqZLGDBhQqODkbLotP0WtLo9R4EJY2PPu5f5Xg4o0rA8FDlmrjFSv9vBBKcfnOSpfYYuu5RTHqg==",
+      "version": "1.4.8",
+      "resolved": "https://registry.npmjs.org/nise/-/nise-1.4.8.tgz",
+      "integrity": "sha512-kGASVhuL4tlAV0tvA34yJYZIVihrUt/5bDwpp4tTluigxUr2bBlJeDXmivb6NuEdFkqvdv/Ybb9dm16PSKUhtw==",
       "dev": true,
       "requires": {
-        "@sinonjs/formatio": "^2.0.0",
-        "just-extend": "^1.1.27",
+        "@sinonjs/formatio": "^3.1.0",
+        "just-extend": "^4.0.2",
         "lolex": "^2.3.2",
         "path-to-regexp": "^1.7.0",
         "text-encoding": "^0.6.4"
+      },
+      "dependencies": {
+        "lolex": {
+          "version": "2.7.5",
+          "resolved": "https://registry.npmjs.org/lolex/-/lolex-2.7.5.tgz",
+          "integrity": "sha512-l9x0+1offnKKIzYVjyXU2SiwhXDLekRzKyhnbyldPHvC7BvLPVpdNUNR2KeMAiCN2D/kLNttZgQD5WjSxuBx3Q==",
+          "dev": true
+        }
       }
     },
     "normalize-package-data": {
@@ -1897,502 +2090,145 @@
       "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
     },
     "nyc": {
-      "version": "11.7.1",
-      "resolved": "https://registry.npmjs.org/nyc/-/nyc-11.7.1.tgz",
-      "integrity": "sha512-EGePURSKUEpS1jWnEKAMhY+GWZzi7JC+f8iBDOATaOsLZW5hM/9eYx2dHGaEXa1ITvMm44CJugMksvP3NwMQMw==",
+      "version": "13.2.0",
+      "resolved": "https://registry.npmjs.org/nyc/-/nyc-13.2.0.tgz",
+      "integrity": "sha512-gQBlOqvfpYt9b2PZ7qElrHWt8x4y8ApNfbMBoDPdl3sY4/4RJwCxDGTSqhA9RnaguZjS5nW7taW8oToe86JLgQ==",
       "dev": true,
       "requires": {
         "archy": "^1.0.0",
         "arrify": "^1.0.1",
-        "caching-transform": "^1.0.0",
-        "convert-source-map": "^1.5.1",
-        "debug-log": "^1.0.1",
-        "default-require-extensions": "^1.0.0",
-        "find-cache-dir": "^0.1.1",
-        "find-up": "^2.1.0",
-        "foreground-child": "^1.5.3",
-        "glob": "^7.0.6",
-        "istanbul-lib-coverage": "^1.1.2",
-        "istanbul-lib-hook": "^1.1.0",
-        "istanbul-lib-instrument": "^1.10.0",
-        "istanbul-lib-report": "^1.1.3",
-        "istanbul-lib-source-maps": "^1.2.3",
-        "istanbul-reports": "^1.4.0",
-        "md5-hex": "^1.2.0",
-        "merge-source-map": "^1.0.2",
-        "micromatch": "^2.3.11",
-        "mkdirp": "^0.5.0",
-        "resolve-from": "^2.0.0",
-        "rimraf": "^2.5.4",
-        "signal-exit": "^3.0.1",
+        "caching-transform": "^3.0.1",
+        "convert-source-map": "^1.6.0",
+        "find-cache-dir": "^2.0.0",
+        "find-up": "^3.0.0",
+        "foreground-child": "^1.5.6",
+        "glob": "^7.1.3",
+        "istanbul-lib-coverage": "^2.0.3",
+        "istanbul-lib-hook": "^2.0.3",
+        "istanbul-lib-instrument": "^3.0.1",
+        "istanbul-lib-report": "^2.0.4",
+        "istanbul-lib-source-maps": "^3.0.2",
+        "istanbul-reports": "^2.1.0",
+        "make-dir": "^1.3.0",
+        "merge-source-map": "^1.1.0",
+        "resolve-from": "^4.0.0",
+        "rimraf": "^2.6.3",
+        "signal-exit": "^3.0.2",
         "spawn-wrap": "^1.4.2",
-        "test-exclude": "^4.2.0",
-        "yargs": "11.1.0",
-        "yargs-parser": "^8.0.0"
+        "test-exclude": "^5.1.0",
+        "uuid": "^3.3.2",
+        "yargs": "^12.0.5",
+        "yargs-parser": "^11.1.1"
       },
       "dependencies": {
-        "align-text": {
-          "version": "0.1.4",
-          "resolved": false,
-          "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
-          "dev": true,
-          "requires": {
-            "kind-of": "^3.0.2",
-            "longest": "^1.0.1",
-            "repeat-string": "^1.5.2"
-          }
-        },
-        "amdefine": {
-          "version": "1.0.1",
-          "resolved": false,
-          "integrity": "sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU=",
-          "dev": true
-        },
         "ansi-regex": {
-          "version": "2.1.1",
-          "resolved": false,
-          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-          "dev": true
-        },
-        "ansi-styles": {
-          "version": "2.2.1",
-          "resolved": false,
-          "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+          "version": "3.0.0",
+          "bundled": true,
           "dev": true
         },
         "append-transform": {
-          "version": "0.4.0",
-          "resolved": false,
-          "integrity": "sha1-126/jKlNJ24keja61EpLdKthGZE=",
+          "version": "1.0.0",
+          "bundled": true,
           "dev": true,
           "requires": {
-            "default-require-extensions": "^1.0.0"
+            "default-require-extensions": "^2.0.0"
           }
         },
         "archy": {
           "version": "1.0.0",
-          "resolved": false,
-          "integrity": "sha1-+cjBN1fMHde8N5rHeyxipcKGjEA=",
-          "dev": true
-        },
-        "arr-diff": {
-          "version": "2.0.0",
-          "resolved": false,
-          "integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
-          "dev": true,
-          "requires": {
-            "arr-flatten": "^1.0.1"
-          }
-        },
-        "arr-flatten": {
-          "version": "1.1.0",
-          "resolved": false,
-          "integrity": "sha512-L3hKV5R/p5o81R7O02IGnwpDmkp6E982XhtbuwSe3O4qOtMMMtodicASA1Cny2U+aCXcNpml+m4dPsvsJ3jatg==",
-          "dev": true
-        },
-        "arr-union": {
-          "version": "3.1.0",
-          "resolved": false,
-          "integrity": "sha1-45sJrqne+Gao8gbiiK9jkZuuOcQ=",
-          "dev": true
-        },
-        "array-unique": {
-          "version": "0.2.1",
-          "resolved": false,
-          "integrity": "sha1-odl8yvy8JiXMcPrc6zalDFiwGlM=",
+          "bundled": true,
           "dev": true
         },
         "arrify": {
           "version": "1.0.1",
-          "resolved": false,
-          "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=",
-          "dev": true
-        },
-        "assign-symbols": {
-          "version": "1.0.0",
-          "resolved": false,
-          "integrity": "sha1-WWZ/QfrdTyDMvCu5a41Pf3jsA2c=",
+          "bundled": true,
           "dev": true
         },
         "async": {
-          "version": "1.5.2",
-          "resolved": false,
-          "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
-          "dev": true
-        },
-        "atob": {
-          "version": "2.1.0",
-          "resolved": false,
-          "integrity": "sha512-SuiKH8vbsOyCALjA/+EINmt/Kdl+TQPrtFgW7XZZcwtryFu9e5kQoX3bjCW6mIvGH1fbeAZZuvwGR5IlBRznGw==",
-          "dev": true
-        },
-        "babel-code-frame": {
-          "version": "6.26.0",
-          "resolved": false,
-          "integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
+          "version": "2.6.1",
+          "bundled": true,
           "dev": true,
           "requires": {
-            "chalk": "^1.1.3",
-            "esutils": "^2.0.2",
-            "js-tokens": "^3.0.2"
+            "lodash": "^4.17.10"
           }
-        },
-        "babel-generator": {
-          "version": "6.26.1",
-          "resolved": false,
-          "integrity": "sha512-HyfwY6ApZj7BYTcJURpM5tznulaBvyio7/0d4zFOeMPUmfxkCjHocCuoLa2SAGzBI8AREcH3eP3758F672DppA==",
-          "dev": true,
-          "requires": {
-            "babel-messages": "^6.23.0",
-            "babel-runtime": "^6.26.0",
-            "babel-types": "^6.26.0",
-            "detect-indent": "^4.0.0",
-            "jsesc": "^1.3.0",
-            "lodash": "^4.17.4",
-            "source-map": "^0.5.7",
-            "trim-right": "^1.0.1"
-          }
-        },
-        "babel-messages": {
-          "version": "6.23.0",
-          "resolved": false,
-          "integrity": "sha1-8830cDhYA1sqKVHG7F7fbGLyYw4=",
-          "dev": true,
-          "requires": {
-            "babel-runtime": "^6.22.0"
-          }
-        },
-        "babel-runtime": {
-          "version": "6.26.0",
-          "resolved": false,
-          "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
-          "dev": true,
-          "requires": {
-            "core-js": "^2.4.0",
-            "regenerator-runtime": "^0.11.0"
-          }
-        },
-        "babel-template": {
-          "version": "6.26.0",
-          "resolved": false,
-          "integrity": "sha1-3gPi0WOWsGn0bdn/+FIfsaDjXgI=",
-          "dev": true,
-          "requires": {
-            "babel-runtime": "^6.26.0",
-            "babel-traverse": "^6.26.0",
-            "babel-types": "^6.26.0",
-            "babylon": "^6.18.0",
-            "lodash": "^4.17.4"
-          }
-        },
-        "babel-traverse": {
-          "version": "6.26.0",
-          "resolved": false,
-          "integrity": "sha1-RqnL1+3MYsjlwGTi0tjQ9ANXZu4=",
-          "dev": true,
-          "requires": {
-            "babel-code-frame": "^6.26.0",
-            "babel-messages": "^6.23.0",
-            "babel-runtime": "^6.26.0",
-            "babel-types": "^6.26.0",
-            "babylon": "^6.18.0",
-            "debug": "^2.6.8",
-            "globals": "^9.18.0",
-            "invariant": "^2.2.2",
-            "lodash": "^4.17.4"
-          }
-        },
-        "babel-types": {
-          "version": "6.26.0",
-          "resolved": false,
-          "integrity": "sha1-o7Bz+Uq0nrb6Vc1lInozQ4BjJJc=",
-          "dev": true,
-          "requires": {
-            "babel-runtime": "^6.26.0",
-            "esutils": "^2.0.2",
-            "lodash": "^4.17.4",
-            "to-fast-properties": "^1.0.3"
-          }
-        },
-        "babylon": {
-          "version": "6.18.0",
-          "resolved": false,
-          "integrity": "sha512-q/UEjfGJ2Cm3oKV71DJz9d25TPnq5rhBVL2Q4fA5wcC3jcrdn7+SssEybFIxwAvvP+YCsCYNKughoF33GxgycQ==",
-          "dev": true
         },
         "balanced-match": {
           "version": "1.0.0",
-          "resolved": false,
-          "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+          "bundled": true,
           "dev": true
-        },
-        "base": {
-          "version": "0.11.2",
-          "resolved": false,
-          "integrity": "sha512-5T6P4xPgpp0YDFvSWwEZ4NoE3aM4QBQXDzmVbraCkFj8zHM+mba8SyqB5DbZWyR7mYHo6Y7BdQo3MoA4m0TeQg==",
-          "dev": true,
-          "requires": {
-            "cache-base": "^1.0.1",
-            "class-utils": "^0.3.5",
-            "component-emitter": "^1.2.1",
-            "define-property": "^1.0.0",
-            "isobject": "^3.0.1",
-            "mixin-deep": "^1.2.0",
-            "pascalcase": "^0.1.1"
-          },
-          "dependencies": {
-            "define-property": {
-              "version": "1.0.0",
-              "resolved": false,
-              "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
-              "dev": true,
-              "requires": {
-                "is-descriptor": "^1.0.0"
-              }
-            },
-            "is-accessor-descriptor": {
-              "version": "1.0.0",
-              "resolved": false,
-              "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
-              "dev": true,
-              "requires": {
-                "kind-of": "^6.0.0"
-              }
-            },
-            "is-data-descriptor": {
-              "version": "1.0.0",
-              "resolved": false,
-              "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
-              "dev": true,
-              "requires": {
-                "kind-of": "^6.0.0"
-              }
-            },
-            "is-descriptor": {
-              "version": "1.0.2",
-              "resolved": false,
-              "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
-              "dev": true,
-              "requires": {
-                "is-accessor-descriptor": "^1.0.0",
-                "is-data-descriptor": "^1.0.0",
-                "kind-of": "^6.0.2"
-              }
-            },
-            "isobject": {
-              "version": "3.0.1",
-              "resolved": false,
-              "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
-              "dev": true
-            },
-            "kind-of": {
-              "version": "6.0.2",
-              "resolved": false,
-              "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
-              "dev": true
-            }
-          }
         },
         "brace-expansion": {
           "version": "1.1.11",
-          "resolved": false,
-          "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+          "bundled": true,
           "dev": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
           }
         },
-        "braces": {
-          "version": "1.8.5",
-          "resolved": false,
-          "integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
-          "dev": true,
-          "requires": {
-            "expand-range": "^1.8.1",
-            "preserve": "^0.2.0",
-            "repeat-element": "^1.1.2"
-          }
-        },
         "builtin-modules": {
           "version": "1.1.1",
-          "resolved": false,
-          "integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8=",
+          "bundled": true,
           "dev": true
         },
-        "cache-base": {
-          "version": "1.0.1",
-          "resolved": false,
-          "integrity": "sha512-AKcdTnFSWATd5/GCPRxr2ChwIJ85CeyrEyjRHlKxQ56d4XJMGym0uAiKn0xbLOGOl3+yRpOTi484dVCEc5AUzQ==",
-          "dev": true,
-          "requires": {
-            "collection-visit": "^1.0.0",
-            "component-emitter": "^1.2.1",
-            "get-value": "^2.0.6",
-            "has-value": "^1.0.0",
-            "isobject": "^3.0.1",
-            "set-value": "^2.0.0",
-            "to-object-path": "^0.3.0",
-            "union-value": "^1.0.0",
-            "unset-value": "^1.0.0"
-          },
-          "dependencies": {
-            "isobject": {
-              "version": "3.0.1",
-              "resolved": false,
-              "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
-              "dev": true
-            }
-          }
-        },
         "caching-transform": {
-          "version": "1.0.1",
-          "resolved": false,
-          "integrity": "sha1-bb2y8g+Nj7znnz6U6dF0Lc31wKE=",
+          "version": "3.0.1",
+          "bundled": true,
           "dev": true,
           "requires": {
-            "md5-hex": "^1.2.0",
-            "mkdirp": "^0.5.1",
-            "write-file-atomic": "^1.1.4"
+            "hasha": "^3.0.0",
+            "make-dir": "^1.3.0",
+            "package-hash": "^3.0.0",
+            "write-file-atomic": "^2.3.0"
           }
         },
         "camelcase": {
-          "version": "1.2.1",
-          "resolved": false,
-          "integrity": "sha1-m7UwTS4LVmmLLHWLCKPqqdqlijk=",
-          "dev": true,
-          "optional": true
-        },
-        "center-align": {
-          "version": "0.1.3",
-          "resolved": false,
-          "integrity": "sha1-qg0yYptu6XIgBBHL1EYckHvCt60=",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "align-text": "^0.1.3",
-            "lazy-cache": "^1.0.3"
-          }
-        },
-        "chalk": {
-          "version": "1.1.3",
-          "resolved": false,
-          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "^2.2.1",
-            "escape-string-regexp": "^1.0.2",
-            "has-ansi": "^2.0.0",
-            "strip-ansi": "^3.0.0",
-            "supports-color": "^2.0.0"
-          }
-        },
-        "class-utils": {
-          "version": "0.3.6",
-          "resolved": false,
-          "integrity": "sha512-qOhPa/Fj7s6TY8H8esGu5QNpMMQxz79h+urzrNYN6mn+9BnxlDGf5QZ+XeCDsxSjPqsSR56XOZOJmpeurnLMeg==",
-          "dev": true,
-          "requires": {
-            "arr-union": "^3.1.0",
-            "define-property": "^0.2.5",
-            "isobject": "^3.0.0",
-            "static-extend": "^0.1.1"
-          },
-          "dependencies": {
-            "define-property": {
-              "version": "0.2.5",
-              "resolved": false,
-              "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
-              "dev": true,
-              "requires": {
-                "is-descriptor": "^0.1.0"
-              }
-            },
-            "isobject": {
-              "version": "3.0.1",
-              "resolved": false,
-              "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
-              "dev": true
-            }
-          }
+          "version": "5.0.0",
+          "bundled": true,
+          "dev": true
         },
         "cliui": {
-          "version": "2.1.0",
-          "resolved": false,
-          "integrity": "sha1-S0dXYP+AJkx2LDoXGQMukcf+oNE=",
+          "version": "4.1.0",
+          "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
-            "center-align": "^0.1.1",
-            "right-align": "^0.1.1",
-            "wordwrap": "0.0.2"
-          },
-          "dependencies": {
-            "wordwrap": {
-              "version": "0.0.2",
-              "resolved": false,
-              "integrity": "sha1-t5Zpu0LstAn4PVg8rVLKF+qhZD8=",
-              "dev": true,
-              "optional": true
-            }
+            "string-width": "^2.1.1",
+            "strip-ansi": "^4.0.0",
+            "wrap-ansi": "^2.0.0"
           }
         },
         "code-point-at": {
           "version": "1.1.0",
-          "resolved": false,
-          "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
+          "bundled": true,
           "dev": true
         },
-        "collection-visit": {
-          "version": "1.0.0",
-          "resolved": false,
-          "integrity": "sha1-S8A3PBZLwykbTTaMgpzxqApZ3KA=",
+        "commander": {
+          "version": "2.17.1",
+          "bundled": true,
           "dev": true,
-          "requires": {
-            "map-visit": "^1.0.0",
-            "object-visit": "^1.0.0"
-          }
+          "optional": true
         },
         "commondir": {
           "version": "1.0.1",
-          "resolved": false,
-          "integrity": "sha1-3dgA2gxmEnOTzKWVDqloo6rxJTs=",
-          "dev": true
-        },
-        "component-emitter": {
-          "version": "1.2.1",
-          "resolved": false,
-          "integrity": "sha1-E3kY1teCg/ffemt8WmPhQOaUJeY=",
+          "bundled": true,
           "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
-          "resolved": false,
-          "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+          "bundled": true,
           "dev": true
         },
         "convert-source-map": {
-          "version": "1.5.1",
-          "resolved": false,
-          "integrity": "sha1-uCeAl7m8IpNl3lxiz1/K7YtVmeU=",
-          "dev": true
-        },
-        "copy-descriptor": {
-          "version": "0.1.1",
-          "resolved": false,
-          "integrity": "sha1-Z29us8OZl8LuGsOpJP1hJHSPV40=",
-          "dev": true
-        },
-        "core-js": {
-          "version": "2.5.5",
-          "resolved": false,
-          "integrity": "sha1-sU3ek2xkDAV5prUMq8wTLdYSfjs=",
-          "dev": true
+          "version": "1.6.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "safe-buffer": "~5.1.1"
+          }
         },
         "cross-spawn": {
           "version": "4.0.2",
-          "resolved": false,
-          "integrity": "sha1-e5JHYhwjrf3ThWAEqCPL45dCTUE=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "lru-cache": "^4.0.1",
@@ -2400,132 +2236,54 @@
           }
         },
         "debug": {
-          "version": "2.6.9",
-          "resolved": false,
-          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "version": "4.1.1",
+          "bundled": true,
           "dev": true,
           "requires": {
-            "ms": "2.0.0"
+            "ms": "^2.1.1"
           }
-        },
-        "debug-log": {
-          "version": "1.0.1",
-          "resolved": false,
-          "integrity": "sha1-IwdjLUwEOCuN+KMvcLiVBG1SdF8=",
-          "dev": true
         },
         "decamelize": {
           "version": "1.2.0",
-          "resolved": false,
-          "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
-          "dev": true
-        },
-        "decode-uri-component": {
-          "version": "0.2.0",
-          "resolved": false,
-          "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=",
+          "bundled": true,
           "dev": true
         },
         "default-require-extensions": {
-          "version": "1.0.0",
-          "resolved": false,
-          "integrity": "sha1-836hXT4T/9m0N9M+GnW1+5eHTLg=",
+          "version": "2.0.0",
+          "bundled": true,
           "dev": true,
           "requires": {
-            "strip-bom": "^2.0.0"
+            "strip-bom": "^3.0.0"
           }
         },
-        "define-property": {
-          "version": "2.0.2",
-          "resolved": false,
-          "integrity": "sha512-jwK2UV4cnPpbcG7+VRARKTZPUWowwXA8bzH5NP6ud0oeAxyYPuGZUAC7hMugpCdz4BeSZl2Dl9k66CHJ/46ZYQ==",
+        "end-of-stream": {
+          "version": "1.4.1",
+          "bundled": true,
           "dev": true,
           "requires": {
-            "is-descriptor": "^1.0.2",
-            "isobject": "^3.0.1"
-          },
-          "dependencies": {
-            "is-accessor-descriptor": {
-              "version": "1.0.0",
-              "resolved": false,
-              "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
-              "dev": true,
-              "requires": {
-                "kind-of": "^6.0.0"
-              }
-            },
-            "is-data-descriptor": {
-              "version": "1.0.0",
-              "resolved": false,
-              "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
-              "dev": true,
-              "requires": {
-                "kind-of": "^6.0.0"
-              }
-            },
-            "is-descriptor": {
-              "version": "1.0.2",
-              "resolved": false,
-              "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
-              "dev": true,
-              "requires": {
-                "is-accessor-descriptor": "^1.0.0",
-                "is-data-descriptor": "^1.0.0",
-                "kind-of": "^6.0.2"
-              }
-            },
-            "isobject": {
-              "version": "3.0.1",
-              "resolved": false,
-              "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
-              "dev": true
-            },
-            "kind-of": {
-              "version": "6.0.2",
-              "resolved": false,
-              "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
-              "dev": true
-            }
-          }
-        },
-        "detect-indent": {
-          "version": "4.0.0",
-          "resolved": false,
-          "integrity": "sha1-920GQ1LN9Docts5hnE7jqUdd4gg=",
-          "dev": true,
-          "requires": {
-            "repeating": "^2.0.0"
+            "once": "^1.4.0"
           }
         },
         "error-ex": {
-          "version": "1.3.1",
-          "resolved": false,
-          "integrity": "sha1-+FWobOYa3E6GIcPNoh56dhLDqNw=",
+          "version": "1.3.2",
+          "bundled": true,
           "dev": true,
           "requires": {
             "is-arrayish": "^0.2.1"
           }
         },
-        "escape-string-regexp": {
-          "version": "1.0.5",
-          "resolved": false,
-          "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
-          "dev": true
-        },
-        "esutils": {
-          "version": "2.0.2",
-          "resolved": false,
-          "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=",
+        "es6-error": {
+          "version": "4.1.1",
+          "bundled": true,
           "dev": true
         },
         "execa": {
-          "version": "0.7.0",
-          "resolved": false,
-          "integrity": "sha1-lEvs00zEHuMqY6n68nrVpl/Fl3c=",
+          "version": "1.0.0",
+          "bundled": true,
           "dev": true,
           "requires": {
-            "cross-spawn": "^5.0.1",
-            "get-stream": "^3.0.0",
+            "cross-spawn": "^6.0.0",
+            "get-stream": "^4.0.0",
             "is-stream": "^1.1.0",
             "npm-run-path": "^2.0.0",
             "p-finally": "^1.0.0",
@@ -2534,167 +2292,67 @@
           },
           "dependencies": {
             "cross-spawn": {
-              "version": "5.1.0",
-              "resolved": false,
-              "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
+              "version": "6.0.5",
+              "bundled": true,
               "dev": true,
               "requires": {
-                "lru-cache": "^4.0.1",
+                "nice-try": "^1.0.4",
+                "path-key": "^2.0.1",
+                "semver": "^5.5.0",
                 "shebang-command": "^1.2.0",
                 "which": "^1.2.9"
               }
             }
           }
         },
-        "expand-brackets": {
-          "version": "0.1.5",
-          "resolved": false,
-          "integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
-          "dev": true,
-          "requires": {
-            "is-posix-bracket": "^0.1.0"
-          }
-        },
-        "expand-range": {
-          "version": "1.8.2",
-          "resolved": false,
-          "integrity": "sha1-opnv/TNf4nIeuujiV+x5ZE/IUzc=",
-          "dev": true,
-          "requires": {
-            "fill-range": "^2.1.0"
-          }
-        },
-        "extend-shallow": {
-          "version": "3.0.2",
-          "resolved": false,
-          "integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
-          "dev": true,
-          "requires": {
-            "assign-symbols": "^1.0.0",
-            "is-extendable": "^1.0.1"
-          },
-          "dependencies": {
-            "is-extendable": {
-              "version": "1.0.1",
-              "resolved": false,
-              "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
-              "dev": true,
-              "requires": {
-                "is-plain-object": "^2.0.4"
-              }
-            }
-          }
-        },
-        "extglob": {
-          "version": "0.3.2",
-          "resolved": false,
-          "integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
-          "dev": true,
-          "requires": {
-            "is-extglob": "^1.0.0"
-          }
-        },
-        "filename-regex": {
-          "version": "2.0.1",
-          "resolved": false,
-          "integrity": "sha1-wcS5vuPglyXdsQa3XB4wH+LxiyY=",
-          "dev": true
-        },
-        "fill-range": {
-          "version": "2.2.3",
-          "resolved": false,
-          "integrity": "sha1-ULd9/X5Gm8dJJHCWNpn+eoSFpyM=",
-          "dev": true,
-          "requires": {
-            "is-number": "^2.1.0",
-            "isobject": "^2.0.0",
-            "randomatic": "^1.1.3",
-            "repeat-element": "^1.1.2",
-            "repeat-string": "^1.5.2"
-          }
-        },
         "find-cache-dir": {
-          "version": "0.1.1",
-          "resolved": false,
-          "integrity": "sha1-yN765XyKUqinhPnjHFfHQumToLk=",
+          "version": "2.0.0",
+          "bundled": true,
           "dev": true,
           "requires": {
             "commondir": "^1.0.1",
-            "mkdirp": "^0.5.1",
-            "pkg-dir": "^1.0.0"
+            "make-dir": "^1.0.0",
+            "pkg-dir": "^3.0.0"
           }
         },
         "find-up": {
-          "version": "2.1.0",
-          "resolved": false,
-          "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
+          "version": "3.0.0",
+          "bundled": true,
           "dev": true,
           "requires": {
-            "locate-path": "^2.0.0"
-          }
-        },
-        "for-in": {
-          "version": "1.0.2",
-          "resolved": false,
-          "integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA=",
-          "dev": true
-        },
-        "for-own": {
-          "version": "0.1.5",
-          "resolved": false,
-          "integrity": "sha1-UmXGgaTylNq78XyVCbZ2OqhFEM4=",
-          "dev": true,
-          "requires": {
-            "for-in": "^1.0.1"
+            "locate-path": "^3.0.0"
           }
         },
         "foreground-child": {
           "version": "1.5.6",
-          "resolved": false,
-          "integrity": "sha1-T9ca0t/elnibmApcCilZN8svXOk=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "cross-spawn": "^4",
             "signal-exit": "^3.0.0"
           }
         },
-        "fragment-cache": {
-          "version": "0.2.1",
-          "resolved": false,
-          "integrity": "sha1-QpD60n8T6Jvn8zeZxrxaCr//DRk=",
-          "dev": true,
-          "requires": {
-            "map-cache": "^0.2.2"
-          }
-        },
         "fs.realpath": {
           "version": "1.0.0",
-          "resolved": false,
-          "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+          "bundled": true,
           "dev": true
         },
         "get-caller-file": {
-          "version": "1.0.2",
-          "resolved": false,
-          "integrity": "sha1-9wLmMSfn4jHBYKgMFVSstw1QR+U=",
+          "version": "1.0.3",
+          "bundled": true,
           "dev": true
         },
         "get-stream": {
-          "version": "3.0.0",
-          "resolved": false,
-          "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=",
-          "dev": true
-        },
-        "get-value": {
-          "version": "2.0.6",
-          "resolved": false,
-          "integrity": "sha1-3BXKHGcjh8p2vTesCjlbogQqLCg=",
-          "dev": true
+          "version": "4.1.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "pump": "^3.0.0"
+          }
         },
         "glob": {
-          "version": "7.1.2",
-          "resolved": false,
-          "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+          "version": "7.1.3",
+          "bundled": true,
           "dev": true,
           "requires": {
             "fs.realpath": "^1.0.0",
@@ -2705,151 +2363,55 @@
             "path-is-absolute": "^1.0.0"
           }
         },
-        "glob-base": {
-          "version": "0.3.0",
-          "resolved": false,
-          "integrity": "sha1-27Fk9iIbHAscz4Kuoyi0l98Oo8Q=",
-          "dev": true,
-          "requires": {
-            "glob-parent": "^2.0.0",
-            "is-glob": "^2.0.0"
-          }
-        },
-        "glob-parent": {
-          "version": "2.0.0",
-          "resolved": false,
-          "integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
-          "dev": true,
-          "requires": {
-            "is-glob": "^2.0.0"
-          }
-        },
-        "globals": {
-          "version": "9.18.0",
-          "resolved": false,
-          "integrity": "sha512-S0nG3CLEQiY/ILxqtztTWH/3iRRdyBLw6KMDxnKMchrtbj2OFmehVh0WUCfW3DUrIgx/qFrJPICrq4Z4sTR9UQ==",
-          "dev": true
-        },
         "graceful-fs": {
-          "version": "4.1.11",
-          "resolved": false,
-          "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
+          "version": "4.1.15",
+          "bundled": true,
           "dev": true
         },
         "handlebars": {
-          "version": "4.0.11",
-          "resolved": false,
-          "integrity": "sha1-Ywo13+ApS8KB7a5v/F0yn8eYLcw=",
+          "version": "4.0.12",
+          "bundled": true,
           "dev": true,
           "requires": {
-            "async": "^1.4.0",
+            "async": "^2.5.0",
             "optimist": "^0.6.1",
-            "source-map": "^0.4.4",
-            "uglify-js": "^2.6"
+            "source-map": "^0.6.1",
+            "uglify-js": "^3.1.4"
           },
           "dependencies": {
             "source-map": {
-              "version": "0.4.4",
-              "resolved": false,
-              "integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
-              "dev": true,
-              "requires": {
-                "amdefine": ">=0.0.4"
-              }
-            }
-          }
-        },
-        "has-ansi": {
-          "version": "2.0.0",
-          "resolved": false,
-          "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
-          "dev": true,
-          "requires": {
-            "ansi-regex": "^2.0.0"
-          }
-        },
-        "has-flag": {
-          "version": "1.0.0",
-          "resolved": false,
-          "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo=",
-          "dev": true
-        },
-        "has-value": {
-          "version": "1.0.0",
-          "resolved": false,
-          "integrity": "sha1-GLKB2lhbHFxR3vJMkw7SmgvmsXc=",
-          "dev": true,
-          "requires": {
-            "get-value": "^2.0.6",
-            "has-values": "^1.0.0",
-            "isobject": "^3.0.0"
-          },
-          "dependencies": {
-            "isobject": {
-              "version": "3.0.1",
-              "resolved": false,
-              "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+              "version": "0.6.1",
+              "bundled": true,
               "dev": true
             }
           }
         },
-        "has-values": {
-          "version": "1.0.0",
-          "resolved": false,
-          "integrity": "sha1-lbC2P+whRmGab+V/51Yo1aOe/k8=",
+        "has-flag": {
+          "version": "3.0.0",
+          "bundled": true,
+          "dev": true
+        },
+        "hasha": {
+          "version": "3.0.0",
+          "bundled": true,
           "dev": true,
           "requires": {
-            "is-number": "^3.0.0",
-            "kind-of": "^4.0.0"
-          },
-          "dependencies": {
-            "is-number": {
-              "version": "3.0.0",
-              "resolved": false,
-              "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
-              "dev": true,
-              "requires": {
-                "kind-of": "^3.0.2"
-              },
-              "dependencies": {
-                "kind-of": {
-                  "version": "3.2.2",
-                  "resolved": false,
-                  "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-                  "dev": true,
-                  "requires": {
-                    "is-buffer": "^1.1.5"
-                  }
-                }
-              }
-            },
-            "kind-of": {
-              "version": "4.0.0",
-              "resolved": false,
-              "integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
-              "dev": true,
-              "requires": {
-                "is-buffer": "^1.1.5"
-              }
-            }
+            "is-stream": "^1.0.1"
           }
         },
         "hosted-git-info": {
-          "version": "2.6.0",
-          "resolved": false,
-          "integrity": "sha512-lIbgIIQA3lz5XaB6vxakj6sDHADJiZadYEJB+FgA+C4nubM1NwcuvUr9EJPmnH1skZqpqUzWborWo8EIUi0Sdw==",
+          "version": "2.7.1",
+          "bundled": true,
           "dev": true
         },
         "imurmurhash": {
           "version": "0.1.4",
-          "resolved": false,
-          "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
+          "bundled": true,
           "dev": true
         },
         "inflight": {
           "version": "1.0.6",
-          "resolved": false,
-          "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "once": "^1.3.0",
@@ -2858,456 +2420,183 @@
         },
         "inherits": {
           "version": "2.0.3",
-          "resolved": false,
-          "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+          "bundled": true,
           "dev": true
-        },
-        "invariant": {
-          "version": "2.2.4",
-          "resolved": false,
-          "integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
-          "dev": true,
-          "requires": {
-            "loose-envify": "^1.0.0"
-          }
         },
         "invert-kv": {
-          "version": "1.0.0",
-          "resolved": false,
-          "integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY=",
+          "version": "2.0.0",
+          "bundled": true,
           "dev": true
-        },
-        "is-accessor-descriptor": {
-          "version": "0.1.6",
-          "resolved": false,
-          "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
-          "dev": true,
-          "requires": {
-            "kind-of": "^3.0.2"
-          }
         },
         "is-arrayish": {
           "version": "0.2.1",
-          "resolved": false,
-          "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
-          "dev": true
-        },
-        "is-buffer": {
-          "version": "1.1.6",
-          "resolved": false,
-          "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
+          "bundled": true,
           "dev": true
         },
         "is-builtin-module": {
           "version": "1.0.0",
-          "resolved": false,
-          "integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "builtin-modules": "^1.0.0"
           }
         },
-        "is-data-descriptor": {
-          "version": "0.1.4",
-          "resolved": false,
-          "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
-          "dev": true,
-          "requires": {
-            "kind-of": "^3.0.2"
-          }
-        },
-        "is-descriptor": {
-          "version": "0.1.6",
-          "resolved": false,
-          "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
-          "dev": true,
-          "requires": {
-            "is-accessor-descriptor": "^0.1.6",
-            "is-data-descriptor": "^0.1.4",
-            "kind-of": "^5.0.0"
-          },
-          "dependencies": {
-            "kind-of": {
-              "version": "5.1.0",
-              "resolved": false,
-              "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
-              "dev": true
-            }
-          }
-        },
-        "is-dotfile": {
-          "version": "1.0.3",
-          "resolved": false,
-          "integrity": "sha1-pqLzL/0t+wT1yiXs0Pa4PPeYoeE=",
-          "dev": true
-        },
-        "is-equal-shallow": {
-          "version": "0.1.3",
-          "resolved": false,
-          "integrity": "sha1-IjgJj8Ih3gvPpdnqxMRdY4qhxTQ=",
-          "dev": true,
-          "requires": {
-            "is-primitive": "^2.0.0"
-          }
-        },
-        "is-extendable": {
-          "version": "0.1.1",
-          "resolved": false,
-          "integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik=",
-          "dev": true
-        },
-        "is-extglob": {
-          "version": "1.0.0",
-          "resolved": false,
-          "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
-          "dev": true
-        },
-        "is-finite": {
-          "version": "1.0.2",
-          "resolved": false,
-          "integrity": "sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko=",
-          "dev": true,
-          "requires": {
-            "number-is-nan": "^1.0.0"
-          }
-        },
         "is-fullwidth-code-point": {
           "version": "2.0.0",
-          "resolved": false,
-          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
-          "dev": true
-        },
-        "is-glob": {
-          "version": "2.0.1",
-          "resolved": false,
-          "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
-          "dev": true,
-          "requires": {
-            "is-extglob": "^1.0.0"
-          }
-        },
-        "is-number": {
-          "version": "2.1.0",
-          "resolved": false,
-          "integrity": "sha1-Afy7s5NGOlSPL0ZszhbezknbkI8=",
-          "dev": true,
-          "requires": {
-            "kind-of": "^3.0.2"
-          }
-        },
-        "is-odd": {
-          "version": "2.0.0",
-          "resolved": false,
-          "integrity": "sha512-OTiixgpZAT1M4NHgS5IguFp/Vz2VI3U7Goh4/HA1adtwyLtSBrxYlcSYkhpAE07s4fKEcjrFxyvtQBND4vFQyQ==",
-          "dev": true,
-          "requires": {
-            "is-number": "^4.0.0"
-          },
-          "dependencies": {
-            "is-number": {
-              "version": "4.0.0",
-              "resolved": false,
-              "integrity": "sha512-rSklcAIlf1OmFdyAqbnWTLVelsQ58uvZ66S/ZyawjWqIviTWCjg2PzVGw8WUA+nNuPTqb4wgA+NszrJ+08LlgQ==",
-              "dev": true
-            }
-          }
-        },
-        "is-plain-object": {
-          "version": "2.0.4",
-          "resolved": false,
-          "integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
-          "dev": true,
-          "requires": {
-            "isobject": "^3.0.1"
-          },
-          "dependencies": {
-            "isobject": {
-              "version": "3.0.1",
-              "resolved": false,
-              "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
-              "dev": true
-            }
-          }
-        },
-        "is-posix-bracket": {
-          "version": "0.1.1",
-          "resolved": false,
-          "integrity": "sha1-MzTceXdDaOkvAW5vvAqI9c1ua8Q=",
-          "dev": true
-        },
-        "is-primitive": {
-          "version": "2.0.0",
-          "resolved": false,
-          "integrity": "sha1-IHurkWOEmcB7Kt8kCkGochADRXU=",
+          "bundled": true,
           "dev": true
         },
         "is-stream": {
           "version": "1.1.0",
-          "resolved": false,
-          "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
-          "dev": true
-        },
-        "is-utf8": {
-          "version": "0.2.1",
-          "resolved": false,
-          "integrity": "sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI=",
-          "dev": true
-        },
-        "is-windows": {
-          "version": "1.0.2",
-          "resolved": false,
-          "integrity": "sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA==",
-          "dev": true
-        },
-        "isarray": {
-          "version": "1.0.0",
-          "resolved": false,
-          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+          "bundled": true,
           "dev": true
         },
         "isexe": {
           "version": "2.0.0",
-          "resolved": false,
-          "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
+          "bundled": true,
           "dev": true
         },
-        "isobject": {
-          "version": "2.1.0",
-          "resolved": false,
-          "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
-          "dev": true,
-          "requires": {
-            "isarray": "1.0.0"
-          }
-        },
         "istanbul-lib-coverage": {
-          "version": "1.2.0",
-          "resolved": false,
-          "integrity": "sha512-GvgM/uXRwm+gLlvkWHTjDAvwynZkL9ns15calTrmhGgowlwJBbWMYzWbKqE2DT6JDP1AFXKa+Zi0EkqNCUqY0A==",
+          "version": "2.0.3",
+          "bundled": true,
           "dev": true
         },
         "istanbul-lib-hook": {
-          "version": "1.1.0",
-          "resolved": false,
-          "integrity": "sha512-U3qEgwVDUerZ0bt8cfl3dSP3S6opBoOtk3ROO5f2EfBr/SRiD9FQqzwaZBqFORu8W7O0EXpai+k7kxHK13beRg==",
+          "version": "2.0.3",
+          "bundled": true,
           "dev": true,
           "requires": {
-            "append-transform": "^0.4.0"
-          }
-        },
-        "istanbul-lib-instrument": {
-          "version": "1.10.1",
-          "resolved": false,
-          "integrity": "sha512-1dYuzkOCbuR5GRJqySuZdsmsNKPL3PTuyPevQfoCXJePT9C8y1ga75neU+Tuy9+yS3G/dgx8wgOmp2KLpgdoeQ==",
-          "dev": true,
-          "requires": {
-            "babel-generator": "^6.18.0",
-            "babel-template": "^6.16.0",
-            "babel-traverse": "^6.18.0",
-            "babel-types": "^6.18.0",
-            "babylon": "^6.18.0",
-            "istanbul-lib-coverage": "^1.2.0",
-            "semver": "^5.3.0"
+            "append-transform": "^1.0.0"
           }
         },
         "istanbul-lib-report": {
-          "version": "1.1.3",
-          "resolved": false,
-          "integrity": "sha512-D4jVbMDtT2dPmloPJS/rmeP626N5Pr3Rp+SovrPn1+zPChGHcggd/0sL29jnbm4oK9W0wHjCRsdch9oLd7cm6g==",
+          "version": "2.0.4",
+          "bundled": true,
           "dev": true,
           "requires": {
-            "istanbul-lib-coverage": "^1.1.2",
-            "mkdirp": "^0.5.1",
-            "path-parse": "^1.0.5",
-            "supports-color": "^3.1.2"
+            "istanbul-lib-coverage": "^2.0.3",
+            "make-dir": "^1.3.0",
+            "supports-color": "^6.0.0"
           },
           "dependencies": {
             "supports-color": {
-              "version": "3.2.3",
-              "resolved": false,
-              "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
+              "version": "6.1.0",
+              "bundled": true,
               "dev": true,
               "requires": {
-                "has-flag": "^1.0.0"
+                "has-flag": "^3.0.0"
               }
             }
           }
         },
         "istanbul-lib-source-maps": {
-          "version": "1.2.3",
-          "resolved": false,
-          "integrity": "sha512-fDa0hwU/5sDXwAklXgAoCJCOsFsBplVQ6WBldz5UwaqOzmDhUK4nfuR7/G//G2lERlblUNJB8P6e8cXq3a7MlA==",
-          "dev": true,
-          "requires": {
-            "debug": "^3.1.0",
-            "istanbul-lib-coverage": "^1.1.2",
-            "mkdirp": "^0.5.1",
-            "rimraf": "^2.6.1",
-            "source-map": "^0.5.3"
-          },
-          "dependencies": {
-            "debug": {
-              "version": "3.1.0",
-              "resolved": false,
-              "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
-              "dev": true,
-              "requires": {
-                "ms": "2.0.0"
-              }
-            }
-          }
-        },
-        "istanbul-reports": {
-          "version": "1.4.0",
-          "resolved": false,
-          "integrity": "sha512-OPzVo1fPZ2H+owr8q/LYKLD+vquv9Pj4F+dj808MdHbuQLD7S4ACRjcX+0Tne5Vxt2lxXvdZaL7v+FOOAV281w==",
-          "dev": true,
-          "requires": {
-            "handlebars": "^4.0.3"
-          }
-        },
-        "js-tokens": {
           "version": "3.0.2",
-          "resolved": false,
-          "integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls=",
-          "dev": true
-        },
-        "jsesc": {
-          "version": "1.3.0",
-          "resolved": false,
-          "integrity": "sha1-RsP+yMGJKxKwgz25vHYiF226s0s=",
-          "dev": true
-        },
-        "kind-of": {
-          "version": "3.2.2",
-          "resolved": false,
-          "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+          "bundled": true,
           "dev": true,
           "requires": {
-            "is-buffer": "^1.1.5"
-          }
-        },
-        "lazy-cache": {
-          "version": "1.0.4",
-          "resolved": false,
-          "integrity": "sha1-odePw6UEdMuAhF07O24dpJpEbo4=",
-          "dev": true,
-          "optional": true
-        },
-        "lcid": {
-          "version": "1.0.0",
-          "resolved": false,
-          "integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
-          "dev": true,
-          "requires": {
-            "invert-kv": "^1.0.0"
-          }
-        },
-        "load-json-file": {
-          "version": "1.1.0",
-          "resolved": false,
-          "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
-          "dev": true,
-          "requires": {
-            "graceful-fs": "^4.1.2",
-            "parse-json": "^2.2.0",
-            "pify": "^2.0.0",
-            "pinkie-promise": "^2.0.0",
-            "strip-bom": "^2.0.0"
-          }
-        },
-        "locate-path": {
-          "version": "2.0.0",
-          "resolved": false,
-          "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
-          "dev": true,
-          "requires": {
-            "p-locate": "^2.0.0",
-            "path-exists": "^3.0.0"
+            "debug": "^4.1.1",
+            "istanbul-lib-coverage": "^2.0.3",
+            "make-dir": "^1.3.0",
+            "rimraf": "^2.6.2",
+            "source-map": "^0.6.1"
           },
           "dependencies": {
-            "path-exists": {
-              "version": "3.0.0",
-              "resolved": false,
-              "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
+            "source-map": {
+              "version": "0.6.1",
+              "bundled": true,
               "dev": true
             }
           }
         },
-        "lodash": {
-          "version": "4.17.5",
-          "resolved": false,
-          "integrity": "sha512-svL3uiZf1RwhH+cWrfZn3A4+U58wbP0tGVTLQPbjplZxZ8ROD9VLuNgsRniTlLe7OlSqR79RUehXgpBW/s0IQw==",
-          "dev": true
-        },
-        "longest": {
-          "version": "1.0.1",
-          "resolved": false,
-          "integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc=",
-          "dev": true
-        },
-        "loose-envify": {
-          "version": "1.3.1",
-          "resolved": false,
-          "integrity": "sha1-0aitM/qc4OcT1l/dCsi3SNR4yEg=",
+        "istanbul-reports": {
+          "version": "2.1.0",
+          "bundled": true,
           "dev": true,
           "requires": {
-            "js-tokens": "^3.0.0"
+            "handlebars": "^4.0.11"
           }
         },
+        "json-parse-better-errors": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true
+        },
+        "lcid": {
+          "version": "2.0.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "invert-kv": "^2.0.0"
+          }
+        },
+        "load-json-file": {
+          "version": "4.0.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "graceful-fs": "^4.1.2",
+            "parse-json": "^4.0.0",
+            "pify": "^3.0.0",
+            "strip-bom": "^3.0.0"
+          }
+        },
+        "locate-path": {
+          "version": "3.0.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "p-locate": "^3.0.0",
+            "path-exists": "^3.0.0"
+          }
+        },
+        "lodash": {
+          "version": "4.17.11",
+          "bundled": true,
+          "dev": true
+        },
+        "lodash.flattendeep": {
+          "version": "4.4.0",
+          "bundled": true,
+          "dev": true
+        },
         "lru-cache": {
-          "version": "4.1.2",
-          "resolved": false,
-          "integrity": "sha512-wgeVXhrDwAWnIF/yZARsFnMBtdFXOg1b8RIrhilp+0iDYN4mdQcNZElDZ0e4B64BhaxeQ5zN7PMyvu7we1kPeQ==",
+          "version": "4.1.5",
+          "bundled": true,
           "dev": true,
           "requires": {
             "pseudomap": "^1.0.2",
             "yallist": "^2.1.2"
           }
         },
-        "map-cache": {
-          "version": "0.2.2",
-          "resolved": false,
-          "integrity": "sha1-wyq9C9ZSXZsFFkW7TyasXcmKDb8=",
-          "dev": true
-        },
-        "map-visit": {
-          "version": "1.0.0",
-          "resolved": false,
-          "integrity": "sha1-7Nyo8TFE5mDxtb1B8S80edmN+48=",
-          "dev": true,
-          "requires": {
-            "object-visit": "^1.0.0"
-          }
-        },
-        "md5-hex": {
+        "make-dir": {
           "version": "1.3.0",
-          "resolved": false,
-          "integrity": "sha1-0sSv6YPENwZiF5uMrRRSGRNQRsQ=",
+          "bundled": true,
           "dev": true,
           "requires": {
-            "md5-o-matic": "^0.1.1"
+            "pify": "^3.0.0"
           }
         },
-        "md5-o-matic": {
-          "version": "0.1.1",
-          "resolved": false,
-          "integrity": "sha1-givM1l4RfFFPqxdrJZRdVBAKA8M=",
-          "dev": true
+        "map-age-cleaner": {
+          "version": "0.1.3",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "p-defer": "^1.0.0"
+          }
         },
         "mem": {
-          "version": "1.1.0",
-          "resolved": false,
-          "integrity": "sha1-Xt1StIXKHZAP5kiVUFOZoN+kX3Y=",
+          "version": "4.0.0",
+          "bundled": true,
           "dev": true,
           "requires": {
-            "mimic-fn": "^1.0.0"
+            "map-age-cleaner": "^0.1.1",
+            "mimic-fn": "^1.0.0",
+            "p-is-promise": "^1.1.0"
           }
         },
         "merge-source-map": {
           "version": "1.1.0",
-          "resolved": false,
-          "integrity": "sha512-Qkcp7P2ygktpMPh2mCQZaf3jhN6D3Z/qVZHSdWvQ+2Ef5HgRAPBO57A77+ENm0CPx2+1Ce/MYKi3ymqdfuqibw==",
+          "bundled": true,
           "dev": true,
           "requires": {
             "source-map": "^0.6.1"
@@ -3315,134 +2604,57 @@
           "dependencies": {
             "source-map": {
               "version": "0.6.1",
-              "resolved": false,
-              "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+              "bundled": true,
               "dev": true
             }
           }
         },
-        "micromatch": {
-          "version": "2.3.11",
-          "resolved": false,
-          "integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
-          "dev": true,
-          "requires": {
-            "arr-diff": "^2.0.0",
-            "array-unique": "^0.2.1",
-            "braces": "^1.8.2",
-            "expand-brackets": "^0.1.4",
-            "extglob": "^0.3.1",
-            "filename-regex": "^2.0.0",
-            "is-extglob": "^1.0.0",
-            "is-glob": "^2.0.1",
-            "kind-of": "^3.0.2",
-            "normalize-path": "^2.0.1",
-            "object.omit": "^2.0.0",
-            "parse-glob": "^3.0.4",
-            "regex-cache": "^0.4.2"
-          }
-        },
         "mimic-fn": {
           "version": "1.2.0",
-          "resolved": false,
-          "integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ==",
+          "bundled": true,
           "dev": true
         },
         "minimatch": {
           "version": "3.0.4",
-          "resolved": false,
-          "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+          "bundled": true,
           "dev": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
         },
         "minimist": {
-          "version": "0.0.8",
-          "resolved": false,
-          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+          "version": "0.0.10",
+          "bundled": true,
           "dev": true
-        },
-        "mixin-deep": {
-          "version": "1.3.1",
-          "resolved": false,
-          "integrity": "sha512-8ZItLHeEgaqEvd5lYBXfm4EZSFCX29Jb9K+lAHhDKzReKBQKj3R+7NOF6tjqYi9t4oI8VUfaWITJQm86wnXGNQ==",
-          "dev": true,
-          "requires": {
-            "for-in": "^1.0.2",
-            "is-extendable": "^1.0.1"
-          },
-          "dependencies": {
-            "is-extendable": {
-              "version": "1.0.1",
-              "resolved": false,
-              "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
-              "dev": true,
-              "requires": {
-                "is-plain-object": "^2.0.4"
-              }
-            }
-          }
         },
         "mkdirp": {
           "version": "0.5.1",
-          "resolved": false,
-          "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "minimist": "0.0.8"
-          }
-        },
-        "ms": {
-          "version": "2.0.0",
-          "resolved": false,
-          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
-          "dev": true
-        },
-        "nanomatch": {
-          "version": "1.2.9",
-          "resolved": false,
-          "integrity": "sha512-n8R9bS8yQ6eSXaV6jHUpKzD8gLsin02w1HSFiegwrs9E098Ylhw5jdyKPaYqvHknHaSCKTPp7C8dGCQ0q9koXA==",
-          "dev": true,
-          "requires": {
-            "arr-diff": "^4.0.0",
-            "array-unique": "^0.3.2",
-            "define-property": "^2.0.2",
-            "extend-shallow": "^3.0.2",
-            "fragment-cache": "^0.2.1",
-            "is-odd": "^2.0.0",
-            "is-windows": "^1.0.2",
-            "kind-of": "^6.0.2",
-            "object.pick": "^1.3.0",
-            "regex-not": "^1.0.0",
-            "snapdragon": "^0.8.1",
-            "to-regex": "^3.0.1"
           },
           "dependencies": {
-            "arr-diff": {
-              "version": "4.0.0",
-              "resolved": false,
-              "integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA=",
-              "dev": true
-            },
-            "array-unique": {
-              "version": "0.3.2",
-              "resolved": false,
-              "integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=",
-              "dev": true
-            },
-            "kind-of": {
-              "version": "6.0.2",
-              "resolved": false,
-              "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
+            "minimist": {
+              "version": "0.0.8",
+              "bundled": true,
               "dev": true
             }
           }
         },
+        "ms": {
+          "version": "2.1.1",
+          "bundled": true,
+          "dev": true
+        },
+        "nice-try": {
+          "version": "1.0.5",
+          "bundled": true,
+          "dev": true
+        },
         "normalize-package-data": {
           "version": "2.4.0",
-          "resolved": false,
-          "integrity": "sha512-9jjUFbTPfEy3R/ad/2oNbKtW9Hgovl5O1FvFWKkKblNXoN/Oou6+9+KKohPK13Yc3/TyunyWhJp6gvRNR/PPAw==",
+          "bundled": true,
           "dev": true,
           "requires": {
             "hosted-git-info": "^2.1.4",
@@ -3451,19 +2663,9 @@
             "validate-npm-package-license": "^3.0.1"
           }
         },
-        "normalize-path": {
-          "version": "2.1.1",
-          "resolved": false,
-          "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
-          "dev": true,
-          "requires": {
-            "remove-trailing-separator": "^1.0.1"
-          }
-        },
         "npm-run-path": {
           "version": "2.0.2",
-          "resolved": false,
-          "integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "path-key": "^2.0.0"
@@ -3471,86 +2673,12 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "resolved": false,
-          "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
+          "bundled": true,
           "dev": true
-        },
-        "object-assign": {
-          "version": "4.1.1",
-          "resolved": false,
-          "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
-          "dev": true
-        },
-        "object-copy": {
-          "version": "0.1.0",
-          "resolved": false,
-          "integrity": "sha1-fn2Fi3gb18mRpBupde04EnVOmYw=",
-          "dev": true,
-          "requires": {
-            "copy-descriptor": "^0.1.0",
-            "define-property": "^0.2.5",
-            "kind-of": "^3.0.3"
-          },
-          "dependencies": {
-            "define-property": {
-              "version": "0.2.5",
-              "resolved": false,
-              "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
-              "dev": true,
-              "requires": {
-                "is-descriptor": "^0.1.0"
-              }
-            }
-          }
-        },
-        "object-visit": {
-          "version": "1.0.1",
-          "resolved": false,
-          "integrity": "sha1-95xEk68MU3e1n+OdOV5BBC3QRbs=",
-          "dev": true,
-          "requires": {
-            "isobject": "^3.0.0"
-          },
-          "dependencies": {
-            "isobject": {
-              "version": "3.0.1",
-              "resolved": false,
-              "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
-              "dev": true
-            }
-          }
-        },
-        "object.omit": {
-          "version": "2.0.1",
-          "resolved": false,
-          "integrity": "sha1-Gpx0SCnznbuFjHbKNXmuKlTr0fo=",
-          "dev": true,
-          "requires": {
-            "for-own": "^0.1.4",
-            "is-extendable": "^0.1.1"
-          }
-        },
-        "object.pick": {
-          "version": "1.3.0",
-          "resolved": false,
-          "integrity": "sha1-h6EKxMFpS9Lhy/U1kaZhQftd10c=",
-          "dev": true,
-          "requires": {
-            "isobject": "^3.0.1"
-          },
-          "dependencies": {
-            "isobject": {
-              "version": "3.0.1",
-              "resolved": false,
-              "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
-              "dev": true
-            }
-          }
         },
         "once": {
           "version": "1.4.0",
-          "resolved": false,
-          "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "wrappy": "1"
@@ -3558,8 +2686,7 @@
         },
         "optimist": {
           "version": "0.6.1",
-          "resolved": false,
-          "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "minimist": "~0.0.1",
@@ -3568,399 +2695,193 @@
         },
         "os-homedir": {
           "version": "1.0.2",
-          "resolved": false,
-          "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
+          "bundled": true,
           "dev": true
         },
         "os-locale": {
-          "version": "2.1.0",
-          "resolved": false,
-          "integrity": "sha512-3sslG3zJbEYcaC4YVAvDorjGxc7tv6KVATnLPZONiljsUncvihe9BQoVCEs0RZ1kmf4Hk9OBqlZfJZWI4GanKA==",
+          "version": "3.1.0",
+          "bundled": true,
           "dev": true,
           "requires": {
-            "execa": "^0.7.0",
-            "lcid": "^1.0.0",
-            "mem": "^1.1.0"
+            "execa": "^1.0.0",
+            "lcid": "^2.0.0",
+            "mem": "^4.0.0"
           }
+        },
+        "p-defer": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true
         },
         "p-finally": {
           "version": "1.0.0",
-          "resolved": false,
-          "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4=",
+          "bundled": true,
+          "dev": true
+        },
+        "p-is-promise": {
+          "version": "1.1.0",
+          "bundled": true,
           "dev": true
         },
         "p-limit": {
-          "version": "1.2.0",
-          "resolved": false,
-          "integrity": "sha512-Y/OtIaXtUPr4/YpMv1pCL5L5ed0rumAaAeBSj12F+bSlMdys7i8oQF/GUJmfpTS/QoaRrS/k6pma29haJpsMng==",
+          "version": "2.1.0",
+          "bundled": true,
           "dev": true,
           "requires": {
-            "p-try": "^1.0.0"
+            "p-try": "^2.0.0"
           }
         },
         "p-locate": {
-          "version": "2.0.0",
-          "resolved": false,
-          "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
+          "version": "3.0.0",
+          "bundled": true,
           "dev": true,
           "requires": {
-            "p-limit": "^1.1.0"
+            "p-limit": "^2.0.0"
           }
         },
         "p-try": {
-          "version": "1.0.0",
-          "resolved": false,
-          "integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M=",
+          "version": "2.0.0",
+          "bundled": true,
           "dev": true
         },
-        "parse-glob": {
-          "version": "3.0.4",
-          "resolved": false,
-          "integrity": "sha1-ssN2z7EfNVE7rdFz7wu246OIORw=",
+        "package-hash": {
+          "version": "3.0.0",
+          "bundled": true,
           "dev": true,
           "requires": {
-            "glob-base": "^0.3.0",
-            "is-dotfile": "^1.0.0",
-            "is-extglob": "^1.0.0",
-            "is-glob": "^2.0.0"
+            "graceful-fs": "^4.1.15",
+            "hasha": "^3.0.0",
+            "lodash.flattendeep": "^4.4.0",
+            "release-zalgo": "^1.0.0"
           }
         },
         "parse-json": {
-          "version": "2.2.0",
-          "resolved": false,
-          "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
+          "version": "4.0.0",
+          "bundled": true,
           "dev": true,
           "requires": {
-            "error-ex": "^1.2.0"
+            "error-ex": "^1.3.1",
+            "json-parse-better-errors": "^1.0.1"
           }
-        },
-        "pascalcase": {
-          "version": "0.1.1",
-          "resolved": false,
-          "integrity": "sha1-s2PlXoAGym/iF4TS2yK9FdeRfxQ=",
-          "dev": true
         },
         "path-exists": {
-          "version": "2.1.0",
-          "resolved": false,
-          "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
-          "dev": true,
-          "requires": {
-            "pinkie-promise": "^2.0.0"
-          }
+          "version": "3.0.0",
+          "bundled": true,
+          "dev": true
         },
         "path-is-absolute": {
           "version": "1.0.1",
-          "resolved": false,
-          "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+          "bundled": true,
           "dev": true
         },
         "path-key": {
           "version": "2.0.1",
-          "resolved": false,
-          "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=",
-          "dev": true
-        },
-        "path-parse": {
-          "version": "1.0.5",
-          "resolved": false,
-          "integrity": "sha1-PBrfhx6pzWyUMbbqK9dKD/BVxME=",
+          "bundled": true,
           "dev": true
         },
         "path-type": {
-          "version": "1.1.0",
-          "resolved": false,
-          "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
+          "version": "3.0.0",
+          "bundled": true,
           "dev": true,
           "requires": {
-            "graceful-fs": "^4.1.2",
-            "pify": "^2.0.0",
-            "pinkie-promise": "^2.0.0"
+            "pify": "^3.0.0"
           }
         },
         "pify": {
-          "version": "2.3.0",
-          "resolved": false,
-          "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
+          "version": "3.0.0",
+          "bundled": true,
           "dev": true
-        },
-        "pinkie": {
-          "version": "2.0.4",
-          "resolved": false,
-          "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA=",
-          "dev": true
-        },
-        "pinkie-promise": {
-          "version": "2.0.1",
-          "resolved": false,
-          "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
-          "dev": true,
-          "requires": {
-            "pinkie": "^2.0.0"
-          }
         },
         "pkg-dir": {
-          "version": "1.0.0",
-          "resolved": false,
-          "integrity": "sha1-ektQio1bstYp1EcFb/TpyTFM89Q=",
+          "version": "3.0.0",
+          "bundled": true,
           "dev": true,
           "requires": {
-            "find-up": "^1.0.0"
-          },
-          "dependencies": {
-            "find-up": {
-              "version": "1.1.2",
-              "resolved": false,
-              "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
-              "dev": true,
-              "requires": {
-                "path-exists": "^2.0.0",
-                "pinkie-promise": "^2.0.0"
-              }
-            }
+            "find-up": "^3.0.0"
           }
-        },
-        "posix-character-classes": {
-          "version": "0.1.1",
-          "resolved": false,
-          "integrity": "sha1-AerA/jta9xoqbAL+q7jB/vfgDqs=",
-          "dev": true
-        },
-        "preserve": {
-          "version": "0.2.0",
-          "resolved": false,
-          "integrity": "sha1-gV7R9uvGWSb4ZbMQwHE7yzMVzks=",
-          "dev": true
         },
         "pseudomap": {
           "version": "1.0.2",
-          "resolved": false,
-          "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM=",
+          "bundled": true,
           "dev": true
         },
-        "randomatic": {
-          "version": "1.1.7",
-          "resolved": false,
-          "integrity": "sha512-D5JUjPyJbaJDkuAazpVnSfVkLlpeO3wDlPROTMLGKG1zMFNFRgrciKo1ltz/AzNTkqE0HzDx655QOL51N06how==",
+        "pump": {
+          "version": "3.0.0",
+          "bundled": true,
           "dev": true,
           "requires": {
-            "is-number": "^3.0.0",
-            "kind-of": "^4.0.0"
-          },
-          "dependencies": {
-            "is-number": {
-              "version": "3.0.0",
-              "resolved": false,
-              "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
-              "dev": true,
-              "requires": {
-                "kind-of": "^3.0.2"
-              },
-              "dependencies": {
-                "kind-of": {
-                  "version": "3.2.2",
-                  "resolved": false,
-                  "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-                  "dev": true,
-                  "requires": {
-                    "is-buffer": "^1.1.5"
-                  }
-                }
-              }
-            },
-            "kind-of": {
-              "version": "4.0.0",
-              "resolved": false,
-              "integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
-              "dev": true,
-              "requires": {
-                "is-buffer": "^1.1.5"
-              }
-            }
+            "end-of-stream": "^1.1.0",
+            "once": "^1.3.1"
           }
         },
         "read-pkg": {
-          "version": "1.1.0",
-          "resolved": false,
-          "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
+          "version": "3.0.0",
+          "bundled": true,
           "dev": true,
           "requires": {
-            "load-json-file": "^1.0.0",
+            "load-json-file": "^4.0.0",
             "normalize-package-data": "^2.3.2",
-            "path-type": "^1.0.0"
+            "path-type": "^3.0.0"
           }
         },
         "read-pkg-up": {
-          "version": "1.0.1",
-          "resolved": false,
-          "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
+          "version": "4.0.0",
+          "bundled": true,
           "dev": true,
           "requires": {
-            "find-up": "^1.0.0",
-            "read-pkg": "^1.0.0"
-          },
-          "dependencies": {
-            "find-up": {
-              "version": "1.1.2",
-              "resolved": false,
-              "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
-              "dev": true,
-              "requires": {
-                "path-exists": "^2.0.0",
-                "pinkie-promise": "^2.0.0"
-              }
-            }
+            "find-up": "^3.0.0",
+            "read-pkg": "^3.0.0"
           }
         },
-        "regenerator-runtime": {
-          "version": "0.11.1",
-          "resolved": false,
-          "integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg==",
-          "dev": true
-        },
-        "regex-cache": {
-          "version": "0.4.4",
-          "resolved": false,
-          "integrity": "sha512-nVIZwtCjkC9YgvWkpM55B5rBhBYRZhAaJbgcFYXXsHnbZ9UZI9nnVWYZpBlCqv9ho2eZryPnWrZGsOdPwVWXWQ==",
+        "release-zalgo": {
+          "version": "1.0.0",
+          "bundled": true,
           "dev": true,
           "requires": {
-            "is-equal-shallow": "^0.1.3"
-          }
-        },
-        "regex-not": {
-          "version": "1.0.2",
-          "resolved": false,
-          "integrity": "sha512-J6SDjUgDxQj5NusnOtdFxDwN/+HWykR8GELwctJ7mdqhcyy1xEc4SRFHUXvxTp661YaVKAjfRLZ9cCqS6tn32A==",
-          "dev": true,
-          "requires": {
-            "extend-shallow": "^3.0.2",
-            "safe-regex": "^1.1.0"
-          }
-        },
-        "remove-trailing-separator": {
-          "version": "1.1.0",
-          "resolved": false,
-          "integrity": "sha1-wkvOKig62tW8P1jg1IJJuSN52O8=",
-          "dev": true
-        },
-        "repeat-element": {
-          "version": "1.1.2",
-          "resolved": false,
-          "integrity": "sha1-7wiaF40Ug7quTZPrmLT55OEdmQo=",
-          "dev": true
-        },
-        "repeat-string": {
-          "version": "1.6.1",
-          "resolved": false,
-          "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc=",
-          "dev": true
-        },
-        "repeating": {
-          "version": "2.0.1",
-          "resolved": false,
-          "integrity": "sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo=",
-          "dev": true,
-          "requires": {
-            "is-finite": "^1.0.0"
+            "es6-error": "^4.0.1"
           }
         },
         "require-directory": {
           "version": "2.1.1",
-          "resolved": false,
-          "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
+          "bundled": true,
           "dev": true
         },
         "require-main-filename": {
           "version": "1.0.1",
-          "resolved": false,
-          "integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE=",
+          "bundled": true,
           "dev": true
         },
         "resolve-from": {
-          "version": "2.0.0",
-          "resolved": false,
-          "integrity": "sha1-lICrIOlP+h2egKgEx+oUdhGWa1c=",
+          "version": "4.0.0",
+          "bundled": true,
           "dev": true
-        },
-        "resolve-url": {
-          "version": "0.2.1",
-          "resolved": false,
-          "integrity": "sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo=",
-          "dev": true
-        },
-        "ret": {
-          "version": "0.1.15",
-          "resolved": false,
-          "integrity": "sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg==",
-          "dev": true
-        },
-        "right-align": {
-          "version": "0.1.3",
-          "resolved": false,
-          "integrity": "sha1-YTObci/mo1FWiSENJOFMlhSGE+8=",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "align-text": "^0.1.1"
-          }
         },
         "rimraf": {
-          "version": "2.6.2",
-          "resolved": false,
-          "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
+          "version": "2.6.3",
+          "bundled": true,
           "dev": true,
           "requires": {
-            "glob": "^7.0.5"
+            "glob": "^7.1.3"
           }
         },
-        "safe-regex": {
-          "version": "1.1.0",
-          "resolved": false,
-          "integrity": "sha1-QKNmnzsHfR6UPURinhV91IAjvy4=",
-          "dev": true,
-          "requires": {
-            "ret": "~0.1.10"
-          }
+        "safe-buffer": {
+          "version": "5.1.2",
+          "bundled": true,
+          "dev": true
         },
         "semver": {
-          "version": "5.5.0",
-          "resolved": false,
-          "integrity": "sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA==",
+          "version": "5.6.0",
+          "bundled": true,
           "dev": true
         },
         "set-blocking": {
           "version": "2.0.0",
-          "resolved": false,
-          "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
+          "bundled": true,
           "dev": true
-        },
-        "set-value": {
-          "version": "2.0.0",
-          "resolved": false,
-          "integrity": "sha512-hw0yxk9GT/Hr5yJEYnHNKYXkIA8mVJgd9ditYZCe16ZczcaELYYcfvaXesNACk2O8O0nTiPQcQhGUQj8JLzeeg==",
-          "dev": true,
-          "requires": {
-            "extend-shallow": "^2.0.1",
-            "is-extendable": "^0.1.1",
-            "is-plain-object": "^2.0.3",
-            "split-string": "^3.0.1"
-          },
-          "dependencies": {
-            "extend-shallow": {
-              "version": "2.0.1",
-              "resolved": false,
-              "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-              "dev": true,
-              "requires": {
-                "is-extendable": "^0.1.0"
-              }
-            }
-          }
         },
         "shebang-command": {
           "version": "1.2.0",
-          "resolved": false,
-          "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "shebang-regex": "^1.0.0"
@@ -3968,159 +2889,17 @@
         },
         "shebang-regex": {
           "version": "1.0.0",
-          "resolved": false,
-          "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
+          "bundled": true,
           "dev": true
         },
         "signal-exit": {
           "version": "3.0.2",
-          "resolved": false,
-          "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
-          "dev": true
-        },
-        "slide": {
-          "version": "1.1.6",
-          "resolved": false,
-          "integrity": "sha1-VusCfWW00tzmyy4tMsTUr8nh1wc=",
-          "dev": true
-        },
-        "snapdragon": {
-          "version": "0.8.2",
-          "resolved": false,
-          "integrity": "sha512-FtyOnWN/wCHTVXOMwvSv26d+ko5vWlIDD6zoUJ7LW8vh+ZBC8QdljveRP+crNrtBwioEUWy/4dMtbBjA4ioNlg==",
-          "dev": true,
-          "requires": {
-            "base": "^0.11.1",
-            "debug": "^2.2.0",
-            "define-property": "^0.2.5",
-            "extend-shallow": "^2.0.1",
-            "map-cache": "^0.2.2",
-            "source-map": "^0.5.6",
-            "source-map-resolve": "^0.5.0",
-            "use": "^3.1.0"
-          },
-          "dependencies": {
-            "define-property": {
-              "version": "0.2.5",
-              "resolved": false,
-              "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
-              "dev": true,
-              "requires": {
-                "is-descriptor": "^0.1.0"
-              }
-            },
-            "extend-shallow": {
-              "version": "2.0.1",
-              "resolved": false,
-              "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-              "dev": true,
-              "requires": {
-                "is-extendable": "^0.1.0"
-              }
-            }
-          }
-        },
-        "snapdragon-node": {
-          "version": "2.1.1",
-          "resolved": false,
-          "integrity": "sha512-O27l4xaMYt/RSQ5TR3vpWCAB5Kb/czIcqUFOM/C4fYcLnbZUc1PkjTAMjof2pBWaSTwOUd6qUHcFGVGj7aIwnw==",
-          "dev": true,
-          "requires": {
-            "define-property": "^1.0.0",
-            "isobject": "^3.0.0",
-            "snapdragon-util": "^3.0.1"
-          },
-          "dependencies": {
-            "define-property": {
-              "version": "1.0.0",
-              "resolved": false,
-              "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
-              "dev": true,
-              "requires": {
-                "is-descriptor": "^1.0.0"
-              }
-            },
-            "is-accessor-descriptor": {
-              "version": "1.0.0",
-              "resolved": false,
-              "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
-              "dev": true,
-              "requires": {
-                "kind-of": "^6.0.0"
-              }
-            },
-            "is-data-descriptor": {
-              "version": "1.0.0",
-              "resolved": false,
-              "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
-              "dev": true,
-              "requires": {
-                "kind-of": "^6.0.0"
-              }
-            },
-            "is-descriptor": {
-              "version": "1.0.2",
-              "resolved": false,
-              "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
-              "dev": true,
-              "requires": {
-                "is-accessor-descriptor": "^1.0.0",
-                "is-data-descriptor": "^1.0.0",
-                "kind-of": "^6.0.2"
-              }
-            },
-            "isobject": {
-              "version": "3.0.1",
-              "resolved": false,
-              "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
-              "dev": true
-            },
-            "kind-of": {
-              "version": "6.0.2",
-              "resolved": false,
-              "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
-              "dev": true
-            }
-          }
-        },
-        "snapdragon-util": {
-          "version": "3.0.1",
-          "resolved": false,
-          "integrity": "sha512-mbKkMdQKsjX4BAL4bRYTj21edOf8cN7XHdYUJEe+Zn99hVEYcMvKPct1IqNe7+AZPirn8BCDOQBHQZknqmKlZQ==",
-          "dev": true,
-          "requires": {
-            "kind-of": "^3.2.0"
-          }
-        },
-        "source-map": {
-          "version": "0.5.7",
-          "resolved": false,
-          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
-          "dev": true
-        },
-        "source-map-resolve": {
-          "version": "0.5.1",
-          "resolved": false,
-          "integrity": "sha512-0KW2wvzfxm8NCTb30z0LMNyPqWCdDGE2viwzUaucqJdkTRXtZiSY3I+2A6nVAjmdOy0I4gU8DwnVVGsk9jvP2A==",
-          "dev": true,
-          "requires": {
-            "atob": "^2.0.0",
-            "decode-uri-component": "^0.2.0",
-            "resolve-url": "^0.2.1",
-            "source-map-url": "^0.4.0",
-            "urix": "^0.1.0"
-          }
-        },
-        "source-map-url": {
-          "version": "0.4.0",
-          "resolved": false,
-          "integrity": "sha1-PpNdfd1zYxuXZZlW1VEo6HtQhKM=",
+          "bundled": true,
           "dev": true
         },
         "spawn-wrap": {
           "version": "1.4.2",
-          "resolved": false,
-          "integrity": "sha512-vMwR3OmmDhnxCVxM8M+xO/FtIp6Ju/mNaDfCMMW7FDcLRTPFWUswec4LXJHTJE2hwTI9O0YBfygu4DalFl7Ylg==",
+          "bundled": true,
           "dev": true,
           "requires": {
             "foreground-child": "^1.5.6",
@@ -4132,9 +2911,8 @@
           }
         },
         "spdx-correct": {
-          "version": "3.0.0",
-          "resolved": false,
-          "integrity": "sha512-N19o9z5cEyc8yQQPukRCZ9EUmb4HUpnrmaL/fxS2pBo2jbfcFRVuFZ/oFC+vZz0MNNk0h80iMn5/S6qGZOL5+g==",
+          "version": "3.1.0",
+          "bundled": true,
           "dev": true,
           "requires": {
             "spdx-expression-parse": "^3.0.0",
@@ -4142,15 +2920,13 @@
           }
         },
         "spdx-exceptions": {
-          "version": "2.1.0",
-          "resolved": false,
-          "integrity": "sha512-4K1NsmrlCU1JJgUrtgEeTVyfx8VaYea9J9LvARxhbHtVtohPs/gFGG5yy49beySjlIMhhXZ4QqujIZEfS4l6Cg==",
+          "version": "2.2.0",
+          "bundled": true,
           "dev": true
         },
         "spdx-expression-parse": {
           "version": "3.0.0",
-          "resolved": false,
-          "integrity": "sha512-Yg6D3XpRD4kkOmTpdgbUiEJFKghJH03fiC1OPll5h/0sO6neh2jqRDVHOQ4o/LMea0tgCkbMgea5ip/e+MkWyg==",
+          "bundled": true,
           "dev": true,
           "requires": {
             "spdx-exceptions": "^2.1.0",
@@ -4158,583 +2934,74 @@
           }
         },
         "spdx-license-ids": {
-          "version": "3.0.0",
-          "resolved": false,
-          "integrity": "sha512-2+EPwgbnmOIl8HjGBXXMd9NAu02vLjOO1nWw4kmeRDFyHn+M/ETfHxQUK0oXg8ctgVnl9t3rosNVsZ1jG61nDA==",
+          "version": "3.0.3",
+          "bundled": true,
           "dev": true
-        },
-        "split-string": {
-          "version": "3.1.0",
-          "resolved": false,
-          "integrity": "sha512-NzNVhJDYpwceVVii8/Hu6DKfD2G+NrQHlS/V/qgv763EYudVwEcMQNxd2lh+0VrUByXN/oJkl5grOhYWvQUYiw==",
-          "dev": true,
-          "requires": {
-            "extend-shallow": "^3.0.0"
-          }
-        },
-        "static-extend": {
-          "version": "0.1.2",
-          "resolved": false,
-          "integrity": "sha1-YICcOcv/VTNyJv1eC1IPNB8ftcY=",
-          "dev": true,
-          "requires": {
-            "define-property": "^0.2.5",
-            "object-copy": "^0.1.0"
-          },
-          "dependencies": {
-            "define-property": {
-              "version": "0.2.5",
-              "resolved": false,
-              "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
-              "dev": true,
-              "requires": {
-                "is-descriptor": "^0.1.0"
-              }
-            }
-          }
         },
         "string-width": {
           "version": "2.1.1",
-          "resolved": false,
-          "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+          "bundled": true,
           "dev": true,
           "requires": {
             "is-fullwidth-code-point": "^2.0.0",
             "strip-ansi": "^4.0.0"
-          },
-          "dependencies": {
-            "ansi-regex": {
-              "version": "3.0.0",
-              "resolved": false,
-              "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
-              "dev": true
-            },
-            "strip-ansi": {
-              "version": "4.0.0",
-              "resolved": false,
-              "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
-              "dev": true,
-              "requires": {
-                "ansi-regex": "^3.0.0"
-              }
-            }
           }
         },
         "strip-ansi": {
-          "version": "3.0.1",
-          "resolved": false,
-          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+          "version": "4.0.0",
+          "bundled": true,
           "dev": true,
           "requires": {
-            "ansi-regex": "^2.0.0"
+            "ansi-regex": "^3.0.0"
           }
         },
         "strip-bom": {
-          "version": "2.0.0",
-          "resolved": false,
-          "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
-          "dev": true,
-          "requires": {
-            "is-utf8": "^0.2.0"
-          }
+          "version": "3.0.0",
+          "bundled": true,
+          "dev": true
         },
         "strip-eof": {
           "version": "1.0.0",
-          "resolved": false,
-          "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8=",
-          "dev": true
-        },
-        "supports-color": {
-          "version": "2.0.0",
-          "resolved": false,
-          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+          "bundled": true,
           "dev": true
         },
         "test-exclude": {
-          "version": "4.2.1",
-          "resolved": false,
-          "integrity": "sha512-qpqlP/8Zl+sosLxBcVKl9vYy26T9NPalxSzzCP/OY6K7j938ui2oKgo+kRZYfxAeIpLqpbVnsHq1tyV70E4lWQ==",
+          "version": "5.1.0",
+          "bundled": true,
           "dev": true,
           "requires": {
             "arrify": "^1.0.1",
-            "micromatch": "^3.1.8",
-            "object-assign": "^4.1.0",
-            "read-pkg-up": "^1.0.1",
+            "minimatch": "^3.0.4",
+            "read-pkg-up": "^4.0.0",
             "require-main-filename": "^1.0.1"
-          },
-          "dependencies": {
-            "arr-diff": {
-              "version": "4.0.0",
-              "resolved": false,
-              "integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA=",
-              "dev": true
-            },
-            "array-unique": {
-              "version": "0.3.2",
-              "resolved": false,
-              "integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=",
-              "dev": true
-            },
-            "braces": {
-              "version": "2.3.2",
-              "resolved": false,
-              "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
-              "dev": true,
-              "requires": {
-                "arr-flatten": "^1.1.0",
-                "array-unique": "^0.3.2",
-                "extend-shallow": "^2.0.1",
-                "fill-range": "^4.0.0",
-                "isobject": "^3.0.1",
-                "repeat-element": "^1.1.2",
-                "snapdragon": "^0.8.1",
-                "snapdragon-node": "^2.0.1",
-                "split-string": "^3.0.2",
-                "to-regex": "^3.0.1"
-              },
-              "dependencies": {
-                "extend-shallow": {
-                  "version": "2.0.1",
-                  "resolved": false,
-                  "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-                  "dev": true,
-                  "requires": {
-                    "is-extendable": "^0.1.0"
-                  }
-                }
-              }
-            },
-            "expand-brackets": {
-              "version": "2.1.4",
-              "resolved": false,
-              "integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
-              "dev": true,
-              "requires": {
-                "debug": "^2.3.3",
-                "define-property": "^0.2.5",
-                "extend-shallow": "^2.0.1",
-                "posix-character-classes": "^0.1.0",
-                "regex-not": "^1.0.0",
-                "snapdragon": "^0.8.1",
-                "to-regex": "^3.0.1"
-              },
-              "dependencies": {
-                "define-property": {
-                  "version": "0.2.5",
-                  "resolved": false,
-                  "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
-                  "dev": true,
-                  "requires": {
-                    "is-descriptor": "^0.1.0"
-                  }
-                },
-                "extend-shallow": {
-                  "version": "2.0.1",
-                  "resolved": false,
-                  "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-                  "dev": true,
-                  "requires": {
-                    "is-extendable": "^0.1.0"
-                  }
-                },
-                "is-accessor-descriptor": {
-                  "version": "0.1.6",
-                  "resolved": false,
-                  "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
-                  "dev": true,
-                  "requires": {
-                    "kind-of": "^3.0.2"
-                  },
-                  "dependencies": {
-                    "kind-of": {
-                      "version": "3.2.2",
-                      "resolved": false,
-                      "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-                      "dev": true,
-                      "requires": {
-                        "is-buffer": "^1.1.5"
-                      }
-                    }
-                  }
-                },
-                "is-data-descriptor": {
-                  "version": "0.1.4",
-                  "resolved": false,
-                  "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
-                  "dev": true,
-                  "requires": {
-                    "kind-of": "^3.0.2"
-                  },
-                  "dependencies": {
-                    "kind-of": {
-                      "version": "3.2.2",
-                      "resolved": false,
-                      "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-                      "dev": true,
-                      "requires": {
-                        "is-buffer": "^1.1.5"
-                      }
-                    }
-                  }
-                },
-                "is-descriptor": {
-                  "version": "0.1.6",
-                  "resolved": false,
-                  "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
-                  "dev": true,
-                  "requires": {
-                    "is-accessor-descriptor": "^0.1.6",
-                    "is-data-descriptor": "^0.1.4",
-                    "kind-of": "^5.0.0"
-                  }
-                },
-                "kind-of": {
-                  "version": "5.1.0",
-                  "resolved": false,
-                  "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
-                  "dev": true
-                }
-              }
-            },
-            "extglob": {
-              "version": "2.0.4",
-              "resolved": false,
-              "integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
-              "dev": true,
-              "requires": {
-                "array-unique": "^0.3.2",
-                "define-property": "^1.0.0",
-                "expand-brackets": "^2.1.4",
-                "extend-shallow": "^2.0.1",
-                "fragment-cache": "^0.2.1",
-                "regex-not": "^1.0.0",
-                "snapdragon": "^0.8.1",
-                "to-regex": "^3.0.1"
-              },
-              "dependencies": {
-                "define-property": {
-                  "version": "1.0.0",
-                  "resolved": false,
-                  "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
-                  "dev": true,
-                  "requires": {
-                    "is-descriptor": "^1.0.0"
-                  }
-                },
-                "extend-shallow": {
-                  "version": "2.0.1",
-                  "resolved": false,
-                  "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-                  "dev": true,
-                  "requires": {
-                    "is-extendable": "^0.1.0"
-                  }
-                }
-              }
-            },
-            "fill-range": {
-              "version": "4.0.0",
-              "resolved": false,
-              "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
-              "dev": true,
-              "requires": {
-                "extend-shallow": "^2.0.1",
-                "is-number": "^3.0.0",
-                "repeat-string": "^1.6.1",
-                "to-regex-range": "^2.1.0"
-              },
-              "dependencies": {
-                "extend-shallow": {
-                  "version": "2.0.1",
-                  "resolved": false,
-                  "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-                  "dev": true,
-                  "requires": {
-                    "is-extendable": "^0.1.0"
-                  }
-                }
-              }
-            },
-            "is-accessor-descriptor": {
-              "version": "1.0.0",
-              "resolved": false,
-              "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
-              "dev": true,
-              "requires": {
-                "kind-of": "^6.0.0"
-              }
-            },
-            "is-data-descriptor": {
-              "version": "1.0.0",
-              "resolved": false,
-              "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
-              "dev": true,
-              "requires": {
-                "kind-of": "^6.0.0"
-              }
-            },
-            "is-descriptor": {
-              "version": "1.0.2",
-              "resolved": false,
-              "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
-              "dev": true,
-              "requires": {
-                "is-accessor-descriptor": "^1.0.0",
-                "is-data-descriptor": "^1.0.0",
-                "kind-of": "^6.0.2"
-              }
-            },
-            "is-number": {
-              "version": "3.0.0",
-              "resolved": false,
-              "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
-              "dev": true,
-              "requires": {
-                "kind-of": "^3.0.2"
-              },
-              "dependencies": {
-                "kind-of": {
-                  "version": "3.2.2",
-                  "resolved": false,
-                  "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-                  "dev": true,
-                  "requires": {
-                    "is-buffer": "^1.1.5"
-                  }
-                }
-              }
-            },
-            "isobject": {
-              "version": "3.0.1",
-              "resolved": false,
-              "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
-              "dev": true
-            },
-            "kind-of": {
-              "version": "6.0.2",
-              "resolved": false,
-              "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
-              "dev": true
-            },
-            "micromatch": {
-              "version": "3.1.10",
-              "resolved": false,
-              "integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
-              "dev": true,
-              "requires": {
-                "arr-diff": "^4.0.0",
-                "array-unique": "^0.3.2",
-                "braces": "^2.3.1",
-                "define-property": "^2.0.2",
-                "extend-shallow": "^3.0.2",
-                "extglob": "^2.0.4",
-                "fragment-cache": "^0.2.1",
-                "kind-of": "^6.0.2",
-                "nanomatch": "^1.2.9",
-                "object.pick": "^1.3.0",
-                "regex-not": "^1.0.0",
-                "snapdragon": "^0.8.1",
-                "to-regex": "^3.0.2"
-              }
-            }
           }
-        },
-        "to-fast-properties": {
-          "version": "1.0.3",
-          "resolved": false,
-          "integrity": "sha1-uDVx+k2MJbguIxsG46MFXeTKGkc=",
-          "dev": true
-        },
-        "to-object-path": {
-          "version": "0.3.0",
-          "resolved": false,
-          "integrity": "sha1-KXWIt7Dn4KwI4E5nL4XB9JmeF68=",
-          "dev": true,
-          "requires": {
-            "kind-of": "^3.0.2"
-          }
-        },
-        "to-regex": {
-          "version": "3.0.2",
-          "resolved": false,
-          "integrity": "sha512-FWtleNAtZ/Ki2qtqej2CXTOayOH9bHDQF+Q48VpWyDXjbYxA4Yz8iDB31zXOBUlOHHKidDbqGVrTUvQMPmBGBw==",
-          "dev": true,
-          "requires": {
-            "define-property": "^2.0.2",
-            "extend-shallow": "^3.0.2",
-            "regex-not": "^1.0.2",
-            "safe-regex": "^1.1.0"
-          }
-        },
-        "to-regex-range": {
-          "version": "2.1.1",
-          "resolved": false,
-          "integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
-          "dev": true,
-          "requires": {
-            "is-number": "^3.0.0",
-            "repeat-string": "^1.6.1"
-          },
-          "dependencies": {
-            "is-number": {
-              "version": "3.0.0",
-              "resolved": false,
-              "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
-              "dev": true,
-              "requires": {
-                "kind-of": "^3.0.2"
-              }
-            }
-          }
-        },
-        "trim-right": {
-          "version": "1.0.1",
-          "resolved": false,
-          "integrity": "sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM=",
-          "dev": true
         },
         "uglify-js": {
-          "version": "2.8.29",
-          "resolved": false,
-          "integrity": "sha1-KcVzMUgFe7Th913zW3qcty5qWd0=",
+          "version": "3.4.9",
+          "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
-            "source-map": "~0.5.1",
-            "uglify-to-browserify": "~1.0.0",
-            "yargs": "~3.10.0"
+            "commander": "~2.17.1",
+            "source-map": "~0.6.1"
           },
           "dependencies": {
-            "yargs": {
-              "version": "3.10.0",
-              "resolved": false,
-              "integrity": "sha1-9+572FfdfB0tOMDnTvvWgdFDH9E=",
+            "source-map": {
+              "version": "0.6.1",
+              "bundled": true,
               "dev": true,
-              "optional": true,
-              "requires": {
-                "camelcase": "^1.0.2",
-                "cliui": "^2.1.0",
-                "decamelize": "^1.0.0",
-                "window-size": "0.1.0"
-              }
+              "optional": true
             }
           }
         },
-        "uglify-to-browserify": {
-          "version": "1.0.2",
-          "resolved": false,
-          "integrity": "sha1-bgkk1r2mta/jSeOabWMoUKD4grc=",
-          "dev": true,
-          "optional": true
-        },
-        "union-value": {
-          "version": "1.0.0",
-          "resolved": false,
-          "integrity": "sha1-XHHDTLW61dzr4+oM0IIHulqhrqQ=",
-          "dev": true,
-          "requires": {
-            "arr-union": "^3.1.0",
-            "get-value": "^2.0.6",
-            "is-extendable": "^0.1.1",
-            "set-value": "^0.4.3"
-          },
-          "dependencies": {
-            "extend-shallow": {
-              "version": "2.0.1",
-              "resolved": false,
-              "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-              "dev": true,
-              "requires": {
-                "is-extendable": "^0.1.0"
-              }
-            },
-            "set-value": {
-              "version": "0.4.3",
-              "resolved": false,
-              "integrity": "sha1-fbCPnT0i3H945Trzw79GZuzfzPE=",
-              "dev": true,
-              "requires": {
-                "extend-shallow": "^2.0.1",
-                "is-extendable": "^0.1.1",
-                "is-plain-object": "^2.0.1",
-                "to-object-path": "^0.3.0"
-              }
-            }
-          }
-        },
-        "unset-value": {
-          "version": "1.0.0",
-          "resolved": false,
-          "integrity": "sha1-g3aHP30jNRef+x5vw6jtDfyKtVk=",
-          "dev": true,
-          "requires": {
-            "has-value": "^0.3.1",
-            "isobject": "^3.0.0"
-          },
-          "dependencies": {
-            "has-value": {
-              "version": "0.3.1",
-              "resolved": false,
-              "integrity": "sha1-ex9YutpiyoJ+wKIHgCVlSEWZXh8=",
-              "dev": true,
-              "requires": {
-                "get-value": "^2.0.3",
-                "has-values": "^0.1.4",
-                "isobject": "^2.0.0"
-              },
-              "dependencies": {
-                "isobject": {
-                  "version": "2.1.0",
-                  "resolved": false,
-                  "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
-                  "dev": true,
-                  "requires": {
-                    "isarray": "1.0.0"
-                  }
-                }
-              }
-            },
-            "has-values": {
-              "version": "0.1.4",
-              "resolved": false,
-              "integrity": "sha1-bWHeldkd/Km5oCCJrThL/49it3E=",
-              "dev": true
-            },
-            "isobject": {
-              "version": "3.0.1",
-              "resolved": false,
-              "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
-              "dev": true
-            }
-          }
-        },
-        "urix": {
-          "version": "0.1.0",
-          "resolved": false,
-          "integrity": "sha1-2pN/emLiH+wf0Y1Js1wpNQZ6bHI=",
+        "uuid": {
+          "version": "3.3.2",
+          "bundled": true,
           "dev": true
         },
-        "use": {
-          "version": "3.1.0",
-          "resolved": false,
-          "integrity": "sha512-6UJEQM/L+mzC3ZJNM56Q4DFGLX/evKGRg15UJHGB9X5j5Z3AFbgZvjUh2yq/UJUY4U5dh7Fal++XbNg1uzpRAw==",
-          "dev": true,
-          "requires": {
-            "kind-of": "^6.0.2"
-          },
-          "dependencies": {
-            "kind-of": {
-              "version": "6.0.2",
-              "resolved": false,
-              "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
-              "dev": true
-            }
-          }
-        },
         "validate-npm-package-license": {
-          "version": "3.0.3",
-          "resolved": false,
-          "integrity": "sha512-63ZOUnL4SIXj4L0NixR3L1lcjO38crAbgrTpl28t8jjrfuiOBL5Iygm+60qPs/KsZGzPNg6Smnc/oY16QTjF0g==",
+          "version": "3.0.4",
+          "bundled": true,
           "dev": true,
           "requires": {
             "spdx-correct": "^3.0.0",
@@ -4742,9 +3009,8 @@
           }
         },
         "which": {
-          "version": "1.3.0",
-          "resolved": false,
-          "integrity": "sha512-xcJpopdamTuY5duC/KnTTNBraPK54YwpenP4lzxU8H91GudWpFv38u0CKjclE1Wi2EH2EDz5LRcHcKbCIzqGyg==",
+          "version": "1.3.1",
+          "bundled": true,
           "dev": true,
           "requires": {
             "isexe": "^2.0.0"
@@ -4752,37 +3018,31 @@
         },
         "which-module": {
           "version": "2.0.0",
-          "resolved": false,
-          "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
+          "bundled": true,
           "dev": true
-        },
-        "window-size": {
-          "version": "0.1.0",
-          "resolved": false,
-          "integrity": "sha1-VDjNLqk7IC76Ohn+iIeu58lPnJ0=",
-          "dev": true,
-          "optional": true
         },
         "wordwrap": {
           "version": "0.0.3",
-          "resolved": false,
-          "integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc=",
+          "bundled": true,
           "dev": true
         },
         "wrap-ansi": {
           "version": "2.1.0",
-          "resolved": false,
-          "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
+          "bundled": true,
           "dev": true,
           "requires": {
             "string-width": "^1.0.1",
             "strip-ansi": "^3.0.1"
           },
           "dependencies": {
+            "ansi-regex": {
+              "version": "2.1.1",
+              "bundled": true,
+              "dev": true
+            },
             "is-fullwidth-code-point": {
               "version": "1.0.0",
-              "resolved": false,
-              "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "number-is-nan": "^1.0.0"
@@ -4790,124 +3050,75 @@
             },
             "string-width": {
               "version": "1.0.2",
-              "resolved": false,
-              "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+              "bundled": true,
               "dev": true,
               "requires": {
                 "code-point-at": "^1.0.0",
                 "is-fullwidth-code-point": "^1.0.0",
                 "strip-ansi": "^3.0.0"
               }
+            },
+            "strip-ansi": {
+              "version": "3.0.1",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "ansi-regex": "^2.0.0"
+              }
             }
           }
         },
         "wrappy": {
           "version": "1.0.2",
-          "resolved": false,
-          "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+          "bundled": true,
           "dev": true
         },
         "write-file-atomic": {
-          "version": "1.3.4",
-          "resolved": false,
-          "integrity": "sha1-+Aek8LHZ6ROuekgRLmzDrxmRtF8=",
+          "version": "2.4.2",
+          "bundled": true,
           "dev": true,
           "requires": {
             "graceful-fs": "^4.1.11",
             "imurmurhash": "^0.1.4",
-            "slide": "^1.1.5"
+            "signal-exit": "^3.0.2"
           }
         },
         "y18n": {
-          "version": "3.2.1",
-          "resolved": false,
-          "integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE=",
+          "version": "4.0.0",
+          "bundled": true,
           "dev": true
         },
         "yallist": {
           "version": "2.1.2",
-          "resolved": false,
-          "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
+          "bundled": true,
           "dev": true
         },
         "yargs": {
-          "version": "11.1.0",
-          "resolved": false,
-          "integrity": "sha512-NwW69J42EsCSanF8kyn5upxvjp5ds+t3+udGBeTbFnERA+lF541DDpMawzo4z6W/QrzNM18D+BPMiOBibnFV5A==",
+          "version": "12.0.5",
+          "bundled": true,
           "dev": true,
           "requires": {
             "cliui": "^4.0.0",
-            "decamelize": "^1.1.1",
-            "find-up": "^2.1.0",
+            "decamelize": "^1.2.0",
+            "find-up": "^3.0.0",
             "get-caller-file": "^1.0.1",
-            "os-locale": "^2.0.0",
+            "os-locale": "^3.0.0",
             "require-directory": "^2.1.1",
             "require-main-filename": "^1.0.1",
             "set-blocking": "^2.0.0",
             "string-width": "^2.0.0",
             "which-module": "^2.0.0",
-            "y18n": "^3.2.1",
-            "yargs-parser": "^9.0.2"
-          },
-          "dependencies": {
-            "ansi-regex": {
-              "version": "3.0.0",
-              "resolved": false,
-              "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
-              "dev": true
-            },
-            "camelcase": {
-              "version": "4.1.0",
-              "resolved": false,
-              "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
-              "dev": true
-            },
-            "cliui": {
-              "version": "4.0.0",
-              "resolved": false,
-              "integrity": "sha512-nY3W5Gu2racvdDk//ELReY+dHjb9PlIcVDFXP72nVIhq2Gy3LuVXYwJoPVudwQnv1shtohpgkdCKT2YaKY0CKw==",
-              "dev": true,
-              "requires": {
-                "string-width": "^2.1.1",
-                "strip-ansi": "^4.0.0",
-                "wrap-ansi": "^2.0.0"
-              }
-            },
-            "strip-ansi": {
-              "version": "4.0.0",
-              "resolved": false,
-              "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
-              "dev": true,
-              "requires": {
-                "ansi-regex": "^3.0.0"
-              }
-            },
-            "yargs-parser": {
-              "version": "9.0.2",
-              "resolved": false,
-              "integrity": "sha1-nM9qQ0YP5O1Aqbto9I1DuKaMwHc=",
-              "dev": true,
-              "requires": {
-                "camelcase": "^4.1.0"
-              }
-            }
+            "y18n": "^3.2.1 || ^4.0.0",
+            "yargs-parser": "^11.1.1"
           }
         },
         "yargs-parser": {
-          "version": "8.1.0",
-          "resolved": false,
-          "integrity": "sha512-yP+6QqN8BmrgW2ggLtTbdrOyBNSI7zBa4IykmiV5R1wl1JWNxQvWhMfMdmzIYtKU7oP3OOInY/tl2ov3BDjnJQ==",
+          "version": "11.1.1",
+          "bundled": true,
           "dev": true,
           "requires": {
-            "camelcase": "^4.1.0"
-          },
-          "dependencies": {
-            "camelcase": {
-              "version": "4.1.0",
-              "resolved": false,
-              "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
-              "dev": true
-            }
+            "camelcase": "^5.0.0",
+            "decamelize": "^1.2.0"
           }
         }
       }
@@ -5371,12 +3582,6 @@
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "dev": true
     },
-    "samsam": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/samsam/-/samsam-1.3.0.tgz",
-      "integrity": "sha512-1HwIYD/8UlOtFS3QO3w7ey+SdSDFE4HRNLZoZRYVQefrOY3l17epswImeB1ijgJFQJodIaHcwkp3r/myBjFVbg==",
-      "dev": true
-    },
     "semver": {
       "version": "5.5.0",
       "resolved": "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz",
@@ -5405,18 +3610,18 @@
       "dev": true
     },
     "sinon": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/sinon/-/sinon-4.5.0.tgz",
-      "integrity": "sha512-trdx+mB0VBBgoYucy6a9L7/jfQOmvGeaKZT4OOJ+lPAtI8623xyGr8wLiE4eojzBS8G9yXbhx42GHUOVLr4X2w==",
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/sinon/-/sinon-7.2.3.tgz",
+      "integrity": "sha512-i6j7sqcLEqTYqUcMV327waI745VASvYuSuQMCjbAwlpAeuCgKZ3LtrjDxAbu+GjNQR0FEDpywtwGCIh8GicNyg==",
       "dev": true,
       "requires": {
-        "@sinonjs/formatio": "^2.0.0",
-        "diff": "^3.1.0",
-        "lodash.get": "^4.4.2",
-        "lolex": "^2.2.0",
-        "nise": "^1.2.0",
-        "supports-color": "^5.1.0",
-        "type-detect": "^4.0.5"
+        "@sinonjs/commons": "^1.3.0",
+        "@sinonjs/formatio": "^3.1.0",
+        "@sinonjs/samsam": "^3.0.2",
+        "diff": "^3.5.0",
+        "lolex": "^3.0.0",
+        "nise": "^1.4.8",
+        "supports-color": "^5.5.0"
       },
       "dependencies": {
         "has-flag": {
@@ -5426,9 +3631,9 @@
           "dev": true
         },
         "supports-color": {
-          "version": "5.4.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
-          "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+          "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
           "dev": true,
           "requires": {
             "has-flag": "^3.0.0"
@@ -5437,9 +3642,9 @@
       }
     },
     "sinon-chai": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/sinon-chai/-/sinon-chai-3.0.0.tgz",
-      "integrity": "sha512-+cqeKiuMZjZs800fRf4kjJR/Pp4p7bYY3ciZHClFNS8tSzJoAcWni/ZUZD8TrfZ+oFRyLiKWX3fTClDATGy5vQ==",
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/sinon-chai/-/sinon-chai-3.3.0.tgz",
+      "integrity": "sha512-r2JhDY7gbbmh5z3Q62pNbrjxZdOAjpsqW/8yxAZRSqLZqowmfGZPGUZPFf3UX36NLis0cv8VEM5IJh9HgkSOAA==",
       "dev": true
     },
     "slice-ansi": {
@@ -5458,6 +3663,12 @@
           "dev": true
         }
       }
+    },
+    "source-map": {
+      "version": "0.5.7",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+      "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+      "dev": true
     },
     "spdx-correct": {
       "version": "3.0.0",
@@ -5735,6 +3946,18 @@
       "requires": {
         "os-tmpdir": "~1.0.2"
       }
+    },
+    "to-fast-properties": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
+      "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
+      "dev": true
+    },
+    "trim-right": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/trim-right/-/trim-right-1.0.1.tgz",
+      "integrity": "sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM=",
+      "dev": true
     },
     "type-check": {
       "version": "0.3.2",

--- a/package.json
+++ b/package.json
@@ -46,10 +46,10 @@
     "jsdoc": "3.5.5",
     "minami": "1.2.3",
     "mocha": "5.0.5",
-    "nyc": "11.7.1",
+    "nyc": "13.2.0",
     "rewire": "4.0.1",
-    "sinon": "4.5.0",
-    "sinon-chai": "3.0.0",
+    "sinon": "7.2.3",
+    "sinon-chai": "3.3.0",
     "standard": "11.0.1",
     "timekeeper": "2.1.2",
     "timeout-as-promise": "1.0.0"


### PR DESCRIPTION
We (sparkswap) received npm alerts for 2 dev dependencies that had patches for CVEs. This PR bumps the version for `nyc` and `sinon` to get rid of these warnings