### PR TITLE
Feature/add request

### DIFF
--- a/src/generate-id.js
+++ b/src/generate-id.js
@@ -1,0 +1,24 @@
+const crypto = require('crypto')
+
+/**
+ * Generate a unique ID with base64 url encoding
+ * @param {number} [numBytes=18] - Number of random bytes to include in the ID
+ * @returns {string} Random string with 4/3*numBytes characters
+ */
+function generateId (numBytes = 18) {
+  return urlEncode(crypto.randomBytes(numBytes).toString('base64'))
+}
+
+/**
+ * Convert a string from Base64 to [Base64url]{@link https://tools.ietf.org/html/rfc4648}
+ * @param {string} base64Str - Base64 encoded String
+ * @returns {string} Base64url encoded string
+ */
+function urlEncode (base64Str) {
+  return base64Str
+    .replace(/=/g, '')
+    .replace(/\+/g, '-')
+    .replace(/\//g, '_')
+}
+
+module.exports = generateId

--- a/src/generate-id.spec.js
+++ b/src/generate-id.spec.js
@@ -1,0 +1,91 @@
+const path = require('path')
+const { sinon, rewire, expect } = require('test/test-helper')
+
+const generateId = rewire(path.resolve(__dirname, 'generate-id'))
+
+describe('generateId', () => {
+  describe('generateId', () => {
+    let urlEncode
+    let crypto
+    let bytes
+    let resetUrlEncode
+    let resetCrypto
+    let randomBase64
+    let randomUrlEncoded
+
+    beforeEach(() => {
+      randomBase64 = 'asfdjJF09809ASDFasdf+asdf/asdf='
+      randomUrlEncoded = 'asfdjJF09809ASDFasdf-asdf_asdf'
+
+      urlEncode = sinon.stub().returns(randomUrlEncoded)
+
+      bytes = {
+        toString: sinon.stub().returns(randomBase64)
+      }
+
+      crypto = {
+        randomBytes: sinon.stub().returns(bytes)
+      }
+
+      resetUrlEncode = generateId.__set__('urlEncode', urlEncode)
+      resetCrypto = generateId.__set__('crypto', crypto)
+    })
+
+    afterEach(() => {
+      resetUrlEncode()
+      resetCrypto()
+    })
+
+    it('creates random data', () => {
+      generateId()
+
+      expect(crypto.randomBytes).to.have.been.calledOnce()
+      expect(crypto.randomBytes).to.have.been.calledWith(18)
+    })
+
+    it('creates random data with the passed amount of bytes', () => {
+      generateId(3)
+
+      expect(crypto.randomBytes).to.have.been.calledOnce()
+      expect(crypto.randomBytes).to.have.been.calledWith(3)
+    })
+
+    it('converts the random data to base64', () => {
+      generateId()
+
+      expect(bytes.toString).to.have.been.calledOnce()
+      expect(bytes.toString).to.have.been.calledWith('base64')
+    })
+
+    it('url encodes the data', () => {
+      expect(generateId()).to.be.eql(randomUrlEncoded)
+
+      expect(urlEncode).to.have.been.calledOnce()
+      expect(urlEncode).to.have.been.calledWith(randomBase64)
+    })
+  })
+
+  describe('urlEncode', () => {
+    let urlEncode
+
+    beforeEach(() => {
+      urlEncode = generateId.__get__('urlEncode')
+    })
+
+    it('strips off trailing equals signs', () => {
+      expect(urlEncode('asf8asuf98uas9f8u===')).to.be.eql('asf8asuf98uas9f8u')
+    })
+
+    it('converts + to -', () => {
+      expect(urlEncode('asdf+asdf+asdf')).to.be.eql('asdf-asdf-asdf')
+    })
+
+    it('converts / to _', () => {
+      expect(urlEncode('asdf/asdf/asdf')).to.be.eql('asdf_asdf_asdf')
+    })
+
+    it('converts them all together', () => {
+      expect(urlEncode('asdf/asdf+asdf/asdf+asdf==')).to.be.eql('asdf_asdf-asdf_asdf-asdf')
+    })
+  })
+})

--- a/src/grpc-method.js
+++ b/src/grpc-method.js
@@ -27,7 +27,7 @@ class GrpcMethod {
    * @param  {string}            messageId - Identifier for log messages and public messages. Typically `[${serviceName}:${methodName}]`
    * @param  {Object}            options
    * @param  {boolean}           options.privateErrors - Whether the errors thrown when running this method should have their messages returned to the user by default.
-   * @param  {Object}            options.logger - Logger to be used by the method
+   * @param  {Object}            options.createLogger - function that when called returns logger
    * @param  {*}                 options.* - additional parameters to be included in each request object
    * @param  {Object}            responses - Response constructors to pass to the method
    * @param  {GrpcMethod~method} auth - method called before request
@@ -43,6 +43,7 @@ class GrpcMethod {
     // Logger helper
     this.messageId = messageId
 
+    // function to create logger
     this.createLogger = createLogger
 
     // Options to include in every request object
@@ -121,61 +122,66 @@ class GrpcMethod {
 
   /**
    * Log the start of a request
-   *
+   * @param {Object} logger Logger to be used by the method
    * @return {void}
    */
-  logRequestStart () {
-    this.logger.info(`Request received: ${this.messageId}`)
+  logRequestStart (logger) {
+    logger.info(`Request received: ${this.messageId}`)
   }
 
   /**
    * Log the parameters of a request
    *
+   * @param {Object} logger Logger to be used by the method
    * @param  {Object} parameters of the request
    * @return {void}
    */
-  logRequestParams (params) {
-    this.logger.debug(`Request made with payload: ${this.messageId}`, params)
+  logRequestParams (logger, params) {
+    logger.debug(`Request made with payload: ${this.messageId}`, params)
   }
 
   /**
    * Log client cancellation of a request
    *
+   * @param {Object} logger Logger to be used by the method
    * @return {void}
    */
-  logRequestCancel () {
-    this.logger.info(`Request cancelled by client: ${this.messageId}`)
+  logRequestCancel (logger) {
+    logger.info(`Request cancelled by client: ${this.messageId}`)
   }
 
   /**
    * Log completion (successful or otherwise) of a request
    *
+   * @param {Object} logger Logger to be used by the method
    * @return {void}
    */
-  logRequestEnd () {
-    this.logger.info(`Request completed: ${this.messageId}`)
+  logRequestEnd (logger) {
+    logger.info(`Request completed: ${this.messageId}`)
   }
 
   /**
    * Log data that will be sent to the client
    *
+   * @param {Object} logger Logger to be used by the method
    * @param  {Object} data
    * @return {void}
    */
-  logResponse (data) {
-    this.logger.info(`Response generated: ${this.messageId}`)
-    this.logger.debug(`Responding with payload: ${this.messageId}`, data)
+  logResponse (logger, data) {
+    logger.info(`Response generated: ${this.messageId}`)
+    logger.debug(`Responding with payload: ${this.messageId}`, data)
   }
 
   /**
    * Log errors generated while handling request
    *
+   * @param {Object} logger Logger to be used by the method
    * @param  {error} err
    * @return {void}
    */
-  logError (err) {
-    this.logger.error(`Error while handling request: ${this.messageId}`)
-    this.logger.error(err.stack)
+  logError (logger, err) {
+    logger.error(`Error while handling request: ${this.messageId}`)
+    logger.error(err.stack)
   }
 }
 

--- a/src/grpc-method.js
+++ b/src/grpc-method.js
@@ -44,7 +44,7 @@ class GrpcMethod {
     this.messageId = messageId
 
     // function to create logger
-    this.createLogger = createLogger
+    this.createRequestLogger = createLogger
 
     // Options to include in every request object
     this.requestOptions = requestOptions

--- a/src/grpc-method.js
+++ b/src/grpc-method.js
@@ -1,6 +1,5 @@
 const grpc = require('grpc')
 const { PublicError } = require('./errors')
-const generateId = require('./generate-id')
 
 /**
  * Abstract class for creating Grpc method wrappers
@@ -34,7 +33,7 @@ class GrpcMethod {
    * @param  {GrpcMethod~method} auth - method called before request
    * @return {GrpcMethod}
    */
-  constructor (method, messageId = '', { privateErrors = false, logger = console, auth = null, requestId = generateId(), ...requestOptions } = {}, responses = {}) {
+  constructor (method, messageId = '', { privateErrors = false, createLogger = (() => console), auth = null, ...requestOptions } = {}, responses = {}) {
     // Method definition
     this.method = method
 
@@ -44,8 +43,9 @@ class GrpcMethod {
     // Logger helper
     this.messageId = messageId
 
+    this.createLogger = createLogger
+
     // Options to include in every request object
-    this.logger = logger
     this.requestOptions = requestOptions
 
     // Response constructors
@@ -53,8 +53,6 @@ class GrpcMethod {
 
     // Authentication middleware definition
     this.auth = auth
-
-    this.requestId = requestId
   }
 
   /**

--- a/src/grpc-method.js
+++ b/src/grpc-method.js
@@ -27,7 +27,7 @@ class GrpcMethod {
    * @param  {string}            messageId - Identifier for log messages and public messages. Typically '[${serviceName}:${methodName}]'
    * @param  {Object}            options
    * @param  {boolean}           options.privateErrors - Whether the errors thrown when running this method should have their messages returned to the user by default.
-   * @param  {Object}            options.createLogger - function that when called returns logger
+   * @param  {Function}          options.createLogger - function that when called returns logger
    * @param  {*}                 options.* - additional parameters to be included in each request object
    * @param  {Object}            responses - Response constructors to pass to the method
    * @param  {GrpcMethod~method} auth - method called before request

--- a/src/grpc-method.js
+++ b/src/grpc-method.js
@@ -1,5 +1,6 @@
 const grpc = require('grpc')
 const { PublicError } = require('./errors')
+const generateId = require('./generate-id')
 
 /**
  * Abstract class for creating Grpc method wrappers
@@ -33,7 +34,7 @@ class GrpcMethod {
    * @param  {GrpcMethod~method} auth - method called before request
    * @return {GrpcMethod}
    */
-  constructor (method, messageId = '', { privateErrors = false, logger = console, auth = null, ...requestOptions } = {}, responses = {}) {
+  constructor (method, messageId = '', { privateErrors = false, logger = console, auth = null, requestId = generateId(), ...requestOptions } = {}, responses = {}) {
     // Method definition
     this.method = method
 
@@ -52,6 +53,8 @@ class GrpcMethod {
 
     // Authentication middleware definition
     this.auth = auth
+
+    this.requestId = requestId
   }
 
   /**

--- a/src/grpc-method.js
+++ b/src/grpc-method.js
@@ -24,7 +24,7 @@ class GrpcMethod {
    * Creates a Grpc method wrapper
    *
    * @param  {GrpcMethod~method} method - Method to be wrapped and called during execution
-   * @param  {string}            messageId - Identifier for log messages and public messages. Typically `[${serviceName}:${methodName}]`
+   * @param  {string}            messageId - Identifier for log messages and public messages. Typically '[${serviceName}:${methodName}]'
    * @param  {Object}            options
    * @param  {boolean}           options.privateErrors - Whether the errors thrown when running this method should have their messages returned to the user by default.
    * @param  {Object}            options.createLogger - function that when called returns logger
@@ -105,7 +105,7 @@ class GrpcMethod {
    * @return {GrpcError}
    */
   grpcError (err, { metadata = {}, status = grpc.status.INTERNAL } = {}) {
-    let message = `Call terminated before completion`
+    let message = 'Call terminated before completion'
 
     // if the error is marked as public, or if this method is publicizing
     // errors by default, we should include the message
@@ -126,7 +126,7 @@ class GrpcMethod {
    * @return {void}
    */
   logRequestStart (logger) {
-    logger.info(`Request received: ${this.messageId}`)
+    logger.info('Request received')
   }
 
   /**
@@ -137,7 +137,7 @@ class GrpcMethod {
    * @return {void}
    */
   logRequestParams (logger, params) {
-    logger.debug(`Request made with payload: ${this.messageId}`, params)
+    logger.debug('Request made with payload', params)
   }
 
   /**
@@ -147,7 +147,7 @@ class GrpcMethod {
    * @return {void}
    */
   logRequestCancel (logger) {
-    logger.info(`Request cancelled by client: ${this.messageId}`)
+    logger.info('Request cancelled by client')
   }
 
   /**
@@ -157,7 +157,7 @@ class GrpcMethod {
    * @return {void}
    */
   logRequestEnd (logger) {
-    logger.info(`Request completed: ${this.messageId}`)
+    logger.info('Request completed')
   }
 
   /**
@@ -168,8 +168,8 @@ class GrpcMethod {
    * @return {void}
    */
   logResponse (logger, data) {
-    logger.info(`Response generated: ${this.messageId}`)
-    logger.debug(`Responding with payload: ${this.messageId}`, data)
+    logger.info('Response generated')
+    logger.debug('Responding with payload', data)
   }
 
   /**
@@ -180,7 +180,7 @@ class GrpcMethod {
    * @return {void}
    */
   logError (logger, err) {
-    logger.error(`Error while handling request: ${this.messageId}`)
+    logger.error('Error while handling request')
     logger.error(err.stack)
   }
 }

--- a/src/grpc-method.spec.js
+++ b/src/grpc-method.spec.js
@@ -14,7 +14,7 @@ describe('GrpcMethod', () => {
   let PublicError
   let method
   let requestOptions
-  let logger
+  let createLogger
   let responses
   let messageId
   let auth
@@ -30,7 +30,7 @@ describe('GrpcMethod', () => {
       status: grpcStatus
     })
 
-    logger = sinon.stub()
+    createLogger = sinon.stub()
     responses = {
       FakeResponse: sinon.stub()
     }
@@ -45,62 +45,62 @@ describe('GrpcMethod', () => {
 
   describe('new', () => {
     it('assigns the method', () => {
-      const grpcMethod = new GrpcMethod(method, messageId, { logger, ...requestOptions }, responses)
+      const grpcMethod = new GrpcMethod(method, messageId, { createLogger, ...requestOptions }, responses)
 
       expect(grpcMethod).to.have.property('method')
       expect(grpcMethod.method).to.be.equal(method)
     })
 
     it('assigns the message id', () => {
-      const grpcMethod = new GrpcMethod(method, messageId, { logger, ...requestOptions }, responses)
+      const grpcMethod = new GrpcMethod(method, messageId, { createLogger, ...requestOptions }, responses)
 
       expect(grpcMethod).to.have.property('messageId')
       expect(grpcMethod.messageId).to.be.equal(messageId)
     })
 
     it('aliases the service logger', () => {
-      const grpcMethod = new GrpcMethod(method, messageId, { logger, ...requestOptions }, responses)
+      const grpcMethod = new GrpcMethod(method, messageId, { createLogger, ...requestOptions }, responses)
 
-      expect(grpcMethod).to.have.property('logger')
-      expect(grpcMethod.logger).to.be.equal(logger)
+      expect(grpcMethod).to.have.property('createLogger')
+      expect(grpcMethod.createLogger).to.be.equal(createLogger)
     })
 
     it('aliases the object of responses', () => {
-      const grpcMethod = new GrpcMethod(method, messageId, { logger, ...requestOptions }, responses)
+      const grpcMethod = new GrpcMethod(method, messageId, { createLogger, ...requestOptions }, responses)
 
       expect(grpcMethod).to.have.property('responses')
       expect(grpcMethod.responses).to.be.equal(responses)
     })
 
     it('assigns the request options', () => {
-      const grpcMethod = new GrpcMethod(method, messageId, { logger, ...requestOptions }, responses)
+      const grpcMethod = new GrpcMethod(method, messageId, { createLogger, ...requestOptions }, responses)
 
       expect(grpcMethod).to.have.property('requestOptions')
       expect(grpcMethod.requestOptions).to.be.eql(requestOptions)
     })
 
     it('assigns an authorization function if present', () => {
-      const grpcMethod = new GrpcMethod(method, messageId, { logger, auth, ...requestOptions }, responses)
+      const grpcMethod = new GrpcMethod(method, messageId, { createLogger, auth, ...requestOptions }, responses)
 
       expect(grpcMethod).to.have.property('auth')
       expect(grpcMethod.auth).to.be.equal(auth)
     })
 
     it('assigns authorization to null', () => {
-      const grpcMethod = new GrpcMethod(method, messageId, { logger, ...requestOptions }, responses)
+      const grpcMethod = new GrpcMethod(method, messageId, { createLogger, ...requestOptions }, responses)
 
       expect(grpcMethod).to.have.property('auth')
       expect(grpcMethod.auth).to.be.null()
     })
 
     it('marks errors public by default', () => {
-      const grpcMethod = new GrpcMethod(method, messageId, { logger, ...requestOptions }, responses)
+      const grpcMethod = new GrpcMethod(method, messageId, { createLogger, ...requestOptions }, responses)
 
       expect(grpcMethod).to.have.property('privateErrors', false)
     })
 
     it('marks errors  private if specified', () => {
-      const grpcMethod = new GrpcMethod(method, messageId, { privateErrors: true, logger, ...requestOptions }, responses)
+      const grpcMethod = new GrpcMethod(method, messageId, { privateErrors: true, createLogger, ...requestOptions }, responses)
 
       expect(grpcMethod).to.have.property('privateErrors', true)
     })
@@ -108,7 +108,7 @@ describe('GrpcMethod', () => {
 
   describe('#exec', () => {
     it('throws the unimplemented exec', () => {
-      const grpcMethod = new GrpcMethod(method, messageId, { logger, ...requestOptions }, responses)
+      const grpcMethod = new GrpcMethod(method, messageId, { createLogger, ...requestOptions }, responses)
 
       expect(grpcMethod.exec).to.throw()
     })
@@ -116,7 +116,7 @@ describe('GrpcMethod', () => {
 
   describe('#register', () => {
     it('binds exec to the GrpcMethod context', () => {
-      const grpcMethod = new GrpcMethod(method, messageId, { logger, ...requestOptions }, responses)
+      const grpcMethod = new GrpcMethod(method, messageId, { createLogger, ...requestOptions }, responses)
 
       grpcMethod.exec = sinon.stub()
 
@@ -133,7 +133,7 @@ describe('GrpcMethod', () => {
     let grpcMethod
 
     beforeEach(() => {
-      grpcMethod = new GrpcMethod(method, messageId, { logger, ...requestOptions }, responses)
+      grpcMethod = new GrpcMethod(method, messageId, { createLogger, ...requestOptions }, responses)
     })
 
     it('creates grpc metadata', () => {
@@ -171,7 +171,7 @@ describe('GrpcMethod', () => {
     let grpcMethod
 
     beforeEach(() => {
-      grpcMethod = new GrpcMethod(method, messageId, { logger, ...requestOptions }, responses)
+      grpcMethod = new GrpcMethod(method, messageId, { createLogger, ...requestOptions }, responses)
     })
 
     it('creates a grpc-compliant error object', () => {
@@ -236,7 +236,7 @@ describe('GrpcMethod', () => {
       const err = new PublicError('fake error')
       const grpcErr = grpcMethod.grpcError(err)
 
-      expect(grpcErr.message).to.include('fake error')      
+      expect(grpcErr.message).to.include('fake error')
     })
   })
 })

--- a/src/grpc-method.spec.js
+++ b/src/grpc-method.spec.js
@@ -61,8 +61,8 @@ describe('GrpcMethod', () => {
     it('aliases the service logger', () => {
       const grpcMethod = new GrpcMethod(method, messageId, { createLogger, ...requestOptions }, responses)
 
-      expect(grpcMethod).to.have.property('createLogger')
-      expect(grpcMethod.createLogger).to.be.equal(createLogger)
+      expect(grpcMethod).to.have.property('createRequestLogger')
+      expect(grpcMethod.createRequestLogger).to.be.equal(createLogger)
     })
 
     it('aliases the object of responses', () => {

--- a/src/grpc-server-streaming-method.js
+++ b/src/grpc-server-streaming-method.js
@@ -1,4 +1,5 @@
 const GrpcMethod = require('./grpc-method')
+const generateId = require('./generate-id')
 
 /**
  * @class Wrapper for Server-streaming Grpc Methods
@@ -29,7 +30,10 @@ class GrpcServerStreamingMethod extends GrpcMethod {
     try {
       this.logRequestStart()
 
-      const { method, auth, logger, requestOptions } = this
+      const { method, auth, createLogger, requestOptions } = this
+
+      const requestId = generateId()
+      const logger = createLogger({ messageId: this.messageId, requestId })
 
       request = {
         params: call.request,

--- a/src/grpc-server-streaming-method.js
+++ b/src/grpc-server-streaming-method.js
@@ -28,7 +28,7 @@ class GrpcServerStreamingMethod extends GrpcMethod {
     let request
 
     try {
-      this.logRequestStart()
+      // this.logRequestStart()
 
       const { method, auth, createLogger, requestOptions } = this
 
@@ -45,16 +45,16 @@ class GrpcServerStreamingMethod extends GrpcMethod {
         ...requestOptions
       }
 
-      this.logRequestParams(request.params)
+      // this.logRequestParams(request.params)
 
       call.on('cancelled', () => {
-        this.logRequestCancel()
-        this.logRequestEnd()
+        // this.logRequestCancel()
+        // this.logRequestEnd()
       })
 
       call.on('error', (e) => {
-        this.logError(e)
-        this.logRequestEnd()
+        // this.logError(e)
+        // this.logRequestEnd()
       })
 
       if (auth) {
@@ -65,7 +65,7 @@ class GrpcServerStreamingMethod extends GrpcMethod {
 
       await method(request, this.responses, responseMetadata)
 
-      this.logRequestEnd()
+      // this.logRequestEnd()
 
       call.end(this.metadata(responseMetadata))
     } catch (e) {
@@ -86,7 +86,7 @@ class GrpcServerStreamingMethod extends GrpcMethod {
    * @return {void}
    */
   send (call, data) {
-    this.logResponse(data)
+    // this.logResponse(data)
     call.write(data)
   }
 }

--- a/src/grpc-server-streaming-method.js
+++ b/src/grpc-server-streaming-method.js
@@ -28,13 +28,13 @@ class GrpcServerStreamingMethod extends GrpcMethod {
     let request
 
     try {
-      const { method, auth, createLogger, requestOptions } = this
+      const { method, auth, createRequestLogger, requestOptions } = this
 
       // generate unique id to be associated with the request
       const requestId = generateId(6)
 
       // create the logger with the requestId and messageid
-      const logger = createLogger({ messageId: this.messageId, requestId })
+      const logger = createRequestLogger({ messageId: this.messageId, requestId })
 
       this.logRequestStart(logger)
 
@@ -46,6 +46,7 @@ class GrpcServerStreamingMethod extends GrpcMethod {
         onError: (fn) => { call.on('error', fn) },
         metadata: call.metadata.getMap(),
         requestId,
+        messageId: this.messageId,
         ...requestOptions
       }
 

--- a/src/grpc-unary-method.js
+++ b/src/grpc-unary-method.js
@@ -26,7 +26,7 @@ class GrpcUnaryMethod extends GrpcMethod {
     let request
 
     try {
-      this.logRequestStart()
+      // this.logRequestStart()
 
       const { method, auth, createLogger, requestOptions } = this
       const requestId = generateId()
@@ -44,7 +44,7 @@ class GrpcUnaryMethod extends GrpcMethod {
         ...requestOptions
       }
 
-      this.logRequestParams(request.params)
+      // this.logRequestParams(request.params)
 
       if (auth) {
         logger.debug('Authenticating GRPC Request')
@@ -54,17 +54,17 @@ class GrpcUnaryMethod extends GrpcMethod {
 
       const response = await method(request, this.responses, responseMetadata)
 
-      this.logResponse(response)
+      // this.logResponse(response)
 
       // sendUnaryData expects a callback-like signature, so we leave the first parameter null in the success case
       return sendUnaryData(null, response, this.metadata(responseMetadata))
     } catch (err) {
-      this.logError(err)
+      // this.logError(err)
 
       // sendUnaryData expects a callback-like signature, so we put the error in the first parameter
       return sendUnaryData(this.grpcError(err), null, this.metadata(responseMetadata))
     } finally {
-      this.logRequestEnd()
+      // this.logRequestEnd()
     }
   }
 }

--- a/src/grpc-unary-method.js
+++ b/src/grpc-unary-method.js
@@ -26,12 +26,16 @@ class GrpcUnaryMethod extends GrpcMethod {
     let request
 
     try {
-      // this.logRequestStart()
-
       const { method, auth, createLogger, requestOptions } = this
-      const requestId = generateId()
 
+      // generate unique id to be associated with the request
+      const requestId = generateId(6)
+
+      // create the logger with the requestId and messageid
       const logger = createLogger({ messageId: this.messageId, requestId })
+
+      this.logRequestStart(logger)
+
       /**
        * Request for the method
        * @type {GrpcUnaryMethod~request}
@@ -44,7 +48,7 @@ class GrpcUnaryMethod extends GrpcMethod {
         ...requestOptions
       }
 
-      // this.logRequestParams(request.params)
+      this.logRequestParams(request.logger, request.params)
 
       if (auth) {
         logger.debug('Authenticating GRPC Request')
@@ -54,17 +58,17 @@ class GrpcUnaryMethod extends GrpcMethod {
 
       const response = await method(request, this.responses, responseMetadata)
 
-      // this.logResponse(response)
+      this.logResponse(request.logger, response)
 
       // sendUnaryData expects a callback-like signature, so we leave the first parameter null in the success case
       return sendUnaryData(null, response, this.metadata(responseMetadata))
     } catch (err) {
-      // this.logError(err)
+      this.logError(request.logger, err)
 
       // sendUnaryData expects a callback-like signature, so we put the error in the first parameter
       return sendUnaryData(this.grpcError(err), null, this.metadata(responseMetadata))
     } finally {
-      // this.logRequestEnd()
+      this.logRequestEnd(request.logger)
     }
   }
 }

--- a/src/grpc-unary-method.js
+++ b/src/grpc-unary-method.js
@@ -1,5 +1,5 @@
 const GrpcMethod = require('./grpc-method')
-
+const generateId = require('./generate-id')
 /**
  * @class Creates a wrapper for Grpc Unary method
  * @extends {GrpcMethod}
@@ -28,8 +28,10 @@ class GrpcUnaryMethod extends GrpcMethod {
     try {
       this.logRequestStart()
 
-      const { method, auth, logger, requestId, requestOptions } = this
+      const { method, auth, createLogger, requestOptions } = this
+      const requestId = generateId()
 
+      const logger = createLogger({ messageId: this.messageId, requestId })
       /**
        * Request for the method
        * @type {GrpcUnaryMethod~request}

--- a/src/grpc-unary-method.js
+++ b/src/grpc-unary-method.js
@@ -28,7 +28,7 @@ class GrpcUnaryMethod extends GrpcMethod {
     try {
       this.logRequestStart()
 
-      const { method, auth, logger, requestOptions } = this
+      const { method, auth, logger, requestId, requestOptions } = this
 
       /**
        * Request for the method
@@ -38,6 +38,7 @@ class GrpcUnaryMethod extends GrpcMethod {
         params: call.request,
         logger,
         metadata: call.metadata.getMap(),
+        requestId,
         ...requestOptions
       }
 

--- a/src/grpc-unary-method.js
+++ b/src/grpc-unary-method.js
@@ -26,13 +26,13 @@ class GrpcUnaryMethod extends GrpcMethod {
     let request
 
     try {
-      const { method, auth, createLogger, requestOptions } = this
+      const { method, auth, createRequestLogger, requestOptions } = this
 
       // generate unique id to be associated with the request
       const requestId = generateId(6)
 
       // create the logger with the requestId and messageid
-      const logger = createLogger({ messageId: this.messageId, requestId })
+      const logger = createRequestLogger({ messageId: this.messageId, requestId })
 
       this.logRequestStart(logger)
 
@@ -45,6 +45,7 @@ class GrpcUnaryMethod extends GrpcMethod {
         logger,
         metadata: call.metadata.getMap(),
         requestId,
+        messageId: this.messageId,
         ...requestOptions
       }
 

--- a/src/grpc-unary-method.spec.js
+++ b/src/grpc-unary-method.spec.js
@@ -24,6 +24,7 @@ describe('GrpcUnaryMethod', () => {
   let metadata
   let metadataContents
   let auth
+  let createLogger
 
   beforeEach(() => {
     GrpcMethod = sinon.stub()
@@ -67,6 +68,8 @@ describe('GrpcUnaryMethod', () => {
       request: 'fake request',
       metadata
     }
+
+    createLogger = sinon.stub().returns(logger)
     sendUnaryData = sinon.stub()
   })
 
@@ -74,12 +77,13 @@ describe('GrpcUnaryMethod', () => {
     let grpcMethod
 
     beforeEach(() => {
-      grpcMethod = new GrpcUnaryMethod(method, messageId, { logger, auth, ...requestOptions }, responses)
+      grpcMethod = new GrpcUnaryMethod(method, messageId, { createLogger, auth, ...requestOptions }, responses)
     })
 
     it('logs the start of the request', () => {
       grpcMethod.exec(call, sendUnaryData)
       expect(logRequestStart).to.have.been.calledOnce()
+      expect(logRequestStart).to.have.been.calledWith(logger)
       expect(logRequestStart).to.have.been.calledBefore(method)
     })
 
@@ -87,7 +91,7 @@ describe('GrpcUnaryMethod', () => {
       grpcMethod.exec(call, sendUnaryData)
       expect(logRequestParams).to.have.been.calledOnce()
       expect(logRequestParams).to.have.been.calledBefore(method)
-      expect(logRequestParams).to.have.been.calledWith(call.request)
+      expect(logRequestParams).to.have.been.calledWith(logger, call.request)
     })
 
     it('calls the assigned method', async () => {
@@ -129,7 +133,7 @@ describe('GrpcUnaryMethod', () => {
     })
 
     it('skips auth if auth parameter is null', () => {
-      grpcMethod = new GrpcUnaryMethod(method, messageId, { logger, ...requestOptions }, responses)
+      grpcMethod = new GrpcUnaryMethod(method, messageId, { createLogger, ...requestOptions }, responses)
       grpcMethod.exec(call, sendUnaryData)
       expect(auth).to.not.have.been.calledOnce()
     })
@@ -156,7 +160,7 @@ describe('GrpcUnaryMethod', () => {
         await grpcMethod.exec(call, sendUnaryData)
 
         expect(logResponse).to.have.been.calledOnce()
-        expect(logResponse).to.have.been.calledWith(fakeResponse)
+        expect(logResponse).to.have.been.calledWith(logger, fakeResponse)
       })
 
       it('sends the method output as unary data', async () => {
@@ -190,7 +194,7 @@ describe('GrpcUnaryMethod', () => {
         await grpcMethod.exec(call, sendUnaryData)
 
         expect(logError).to.have.been.calledOnce()
-        expect(logError).to.have.been.calledWith(fakeError)
+        expect(logError).to.have.been.calledWith(logger, fakeError)
       })
 
       it('sends an error as unary data', async () => {
@@ -223,6 +227,7 @@ describe('GrpcUnaryMethod', () => {
       await grpcMethod.exec(call, sendUnaryData)
 
       expect(logRequestEnd).to.have.been.calledOnce()
+      expect(logRequestEnd).to.have.been.calledWith(logger)
     })
 
     it('logs on failed request end', async () => {
@@ -231,6 +236,7 @@ describe('GrpcUnaryMethod', () => {
       await grpcMethod.exec(call, sendUnaryData)
 
       expect(logRequestEnd).to.have.been.calledOnce()
+      expect(logRequestEnd).to.have.been.calledWith(logger)
     })
   })
 })


### PR DESCRIPTION
In order to add a requestId to the logger, we need to attach this requestId when the request is being made. This means passing a function to create a logger instead of  passing the already created logger so that the logger is configured with the requestId.

