### PR TITLE
version bump to 0.7.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "grpc-methods",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "grpc-methods",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "description": "Method wrappers for Grpc to include logging and promises",
   "main": "src/index.js",
   "scripts": {


### PR DESCRIPTION
This bumps the version of grpc-methods to 0.7.1 in order to include #18.