### PR TITLE
Use latest npm for circle ci builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,6 +12,9 @@ jobs:
     steps:
       - checkout
 
+      # Make sure we are on atleast v6 npm
+      - run: npm i -g npm@6
+
       # Download and cache dependencies
       - restore_cache:
           keys:


### PR DESCRIPTION
Update our CI scripts to have npm at the latest version when we run specs or install things from cache. This should prevent any caching issues from earlier versions of npm