### PR TITLE
Remove unnecessary error event handler from ServerWritableStream

### DIFF
--- a/src/grpc-server-streaming-method.js
+++ b/src/grpc-server-streaming-method.js
@@ -57,11 +57,6 @@ class GrpcServerStreamingMethod extends GrpcMethod {
         this.logRequestEnd(request.logger)
       })
 
-      call.on('error', (e) => {
-        this.logError(request.logger, e)
-        this.logRequestEnd(request.logger)
-      })
-
       if (auth) {
         logger.debug('Authenticating GRPC Request')
         await auth(request)


### PR DESCRIPTION
According to the documentation for ServerWritableStream there is no error event so the handler can only be triggered from the server side, which is unnecessary.
https://grpc.github.io/grpc/node/grpc-ServerWritableStream.html#~event:cancelled

This was producing a bug where PublicErrors were being double-logged with the second one being logged as a private error.