### PR TITLE
Remove unnecessary onError handler

### DIFF
--- a/src/grpc-server-streaming-method.js
+++ b/src/grpc-server-streaming-method.js
@@ -43,7 +43,6 @@ class GrpcServerStreamingMethod extends GrpcMethod {
         logger,
         send: this.send.bind(this, call, logger),
         onCancel: (fn) => { call.on('cancelled', fn) },
-        onError: (fn) => { call.on('error', fn) },
         metadata: call.metadata.getMap(),
         requestId,
         messageId: this.messageId,

--- a/src/grpc-server-streaming-method.spec.js
+++ b/src/grpc-server-streaming-method.spec.js
@@ -157,24 +157,6 @@ describe('GrpcServerStreamingMethod', () => {
         expect(call.on).to.have.been.calledWith('cancelled', fakeListener)
       })
 
-      it('includes an onError function', async () => {
-        await grpcMethod.exec(call)
-        expect(method).to.have.been.calledWith(sinon.match({ send: sinon.match.func }))
-      })
-
-      it('sets onError to the cancelled handler', async () => {
-        const fakeListener = function () {
-          return 'myfake'
-        }
-
-        await grpcMethod.exec(call)
-        const request = method.args[0][0]
-
-        request.onError(fakeListener)
-
-        expect(call.on).to.have.been.calledWith('error', fakeListener)
-      })
-
       it('includes the client metadata', async () => {
         await grpcMethod.exec(call)
         expect(method).to.have.been.calledWith(sinon.match({ metadata: metadataContents }))


### PR DESCRIPTION
The onError method of the grpc request object could never be called since the only event is `canceled`, so we can remove it.